### PR TITLE
Angular Signals Modernization

### DIFF
--- a/.agent-context/knowledge/architecture-principles.md
+++ b/.agent-context/knowledge/architecture-principles.md
@@ -169,7 +169,8 @@ The Angular frontend uses two complementary patterns for state management:
 | Undo/redo | Client-side command stacks |
 | Canvas rendering | Imperative HTML Canvas (not declarative) |
 | Component architecture | Standalone components with `inject()` DI |
-| Signal adoption | `signal()`, `computed()`, `input()`, `output()` for local state |
+| Signal adoption | Full — `signal()`, `computed()`, `input()`, `output()`, `viewChild()`, `effect()` across all components |
+| Subscription cleanup | `takeUntilDestroyed(DestroyRef)` for manual subscriptions; `toSignal()` where practical |
 
 **Key files:** `src/eventstormingboard.client/src/app/_shared/services/boards-signalr.service.ts`, `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts`, `src/eventstormingboard.client/src/app/board/board.commands.ts`
 

--- a/.agent-context/knowledge/user-journeys.md
+++ b/.agent-context/knowledge/user-journeys.md
@@ -1,6 +1,6 @@
 # User Journeys
 
-User journeys for StormSpace, documented for automated browser testing by AI agents using VS Code integrated browser tools (`read_page`, `click_element`, `type_in_page`, `screenshot_page`, etc.).
+User journeys for StormSpace, documented for automated browser testing by AI agents using `playwright-cli` (see `.github/skills/playwright-cli/SKILL.md`). All interactions use `playwright-cli` commands via terminal execution.
 
 ## Routing & Navigation
 
@@ -42,19 +42,23 @@ The **STORMSPACE logo** in the nav bar is clickable and navigates back to the sp
 
 **Precondition**: On splash page (`/`)
 
+> **⚠ Display name required**: `createNewBoard()` is gated by `if (this.userName)`. If the display name field is empty, clicking NEW BOARD does nothing — no error, no disabled state, no toast. Always fill the display name first. Skip step 0 if the name is already pre-filled (persisted from a previous session — the user avatar will show an initial letter instead of a `person` icon).
+
 ### Steps
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click NEW BOARD | `click_element(element="NEW BOARD button")` | "Create Storm Board" dialog opens |
-| 2 | Type board name | `type_in_page(element="Board Name input", ref=<textbox "Board Name">, text="My Board")` | Text appears in input; Create button becomes enabled |
-| 3 | *(Optional)* Expand board context | `click_element(element="Optional Board Context for AI")` | Domain and Session Scope fields appear |
-| 4 | *(Optional)* Fill Domain | `type_in_page(ref=<textbox "Domain">, text="eCommerce marketplace")` | Domain text entered |
-| 5 | *(Optional)* Fill Session Scope | `type_in_page(ref=<textbox "Session Scope">, text="Order fulfillment flow")` | Session scope text entered |
-| 6 | Click Create | `click_element(element="Create button")` | Navigates to `/boards/{id}`, board page loads |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------||
+| 0 | Fill display name | `playwright-cli fill <ref of "Enter your name" textbox> "Tester"` then `playwright-cli press Tab` | User avatar in nav bar shows initial letter (e.g. "T") instead of `person` icon |
+| 1 | Click NEW BOARD | `playwright-cli click <ref of "NEW BOARD" button>` | "Create Storm Board" dialog opens |
+| 2 | Type board name | `playwright-cli fill <ref of "Board Name" textbox> "My Board"` | Text appears in input; Create button becomes enabled |
+| 3 | *(Optional)* Expand board context | `playwright-cli click <ref of "Optional Board Context for AI">` | Domain and Session Scope fields appear |
+| 4 | *(Optional)* Fill Domain | `playwright-cli fill <ref of "Domain" textbox> "eCommerce marketplace"` | Domain text entered |
+| 5 | *(Optional)* Fill Session Scope | `playwright-cli fill <ref of "Session Scope" textbox> "Order fulfillment flow"` | Session scope text entered |
+| 6 | Click Create | `playwright-cli click <ref of "Create" button>` | Navigates to `/boards/{id}`, board page loads |
 
 ### Verification
 
+After navigating, run `playwright-cli snapshot` and verify:
 - URL pattern: `/boards/{guid}`
 - Board name input in top bar shows entered name: `textbox "Enter board name"`
 - Status bar shows "0 NOTES" and "0 CONNECTIONS"
@@ -83,18 +87,23 @@ dialog "Create Storm Board"
 
 **Precondition**: On splash page (`/`), at least one board exists
 
+> **⚠ Display name required**: Same as Journey 1 — `selectExistingBoard()` is also gated by `if (this.userName)`. Fill display name first if not already set.
+>
+> **⚠ JOIN BOARD disabled when no boards exist**: The JOIN BOARD button is `[disabled]` when there are no existing boards. Ensure at least one board has been created first (e.g. run Journey 1 beforehand).
+
 ### Steps
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click JOIN BOARD | `click_element(element="JOIN BOARD button")` | "Select a Board" dialog opens |
-| 2 | Click Board Name dropdown | `click_element(ref=<combobox "Board Name">)` | Dropdown expands showing available boards |
-| 3 | Select a board | `click_element(ref=<option "Board Name">)` | Board selected; Select button becomes enabled |
-| 4 | Click Select | `click_element(element="Select button")` | Navigates to `/boards/{id}` |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------||
+| 0 | Fill display name (if not pre-filled) | `playwright-cli fill <ref of "Enter your name" textbox> "Tester"` then `playwright-cli press Tab` | User avatar shows initial letter |
+| 1 | Click JOIN BOARD | `playwright-cli click <ref of "JOIN BOARD" button>` | "Select a Board" dialog opens |
+| 2 | Click Board Name dropdown | `playwright-cli click <ref of "Board Name" combobox>` | Dropdown expands showing available boards |
+| 3 | Select a board | `playwright-cli click <ref of board option>` | Board selected; Select button becomes enabled |
+| 4 | Click Select | `playwright-cli click <ref of "Select" button>` | Navigates to `/boards/{id}` |
 
 ### Alternative: Direct URL
 
-Navigate directly to `https://localhost:51710/boards/{board-id}` — auto-joins and loads the board.
+Navigate directly via `playwright-cli goto https://localhost:51710/boards/{board-id}` — auto-joins and loads the board.
 
 ### Dialog Structure
 
@@ -200,10 +209,10 @@ Phase steps are clickable. Container: `progressbar "Event Storming Phase"`. Indi
 
 ### Steps
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click note type button (e.g. EVENT) | `click_element(element="EVENT button")` | Note created at top-left of canvas viewport |
-| 2 | Verify note count | Read status bar | Note count increments (e.g. "1 NOTES") |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Click note type button (e.g. EVENT) | `playwright-cli click <ref of "EVENT" button>` | Note created at top-left of canvas viewport |
+| 2 | Verify note count | `playwright-cli snapshot` and read status bar | Note count increments (e.g. "1 NOTES") |
 
 Note creation places the note at the top-left of the current canvas viewport. Each toolbar button press creates one note.
 
@@ -211,70 +220,65 @@ Note creation places the note at the top-left of the current canvas viewport. Ea
 
 ### Edit Note Text
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Double-click a note on canvas | `click_element(selector="canvas.storming-canvas", dblClick=true)` | Note text edit modal opens |
-| 2 | Type new text | `type_in_page(text="Order Placed")` | Text entered in modal |
-| 3 | Confirm edit | Click Save/OK or press Enter | Modal closes, note displays new text |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Double-click a note on canvas | `playwright-cli dblclick <ref of canvas.storming-canvas>` | Note text edit modal opens |
+| 2 | Type new text | `playwright-cli type "Order Placed"` | Text entered in modal |
+| 3 | Confirm edit | Click Save/OK or `playwright-cli press Enter` | Modal closes, note displays new text |
 
 ### Select and Delete Notes
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Ensure SELECT mode active | `click_element(element="SELECT button")` | SELECT button shows `.active` |
-| 2 | Click a note on canvas | `click_element(selector="canvas.storming-canvas")` | Note selected (visual highlight) |
-| 3 | Press Delete | `type_in_page(key="Delete")` | Note removed; count decrements |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Ensure SELECT mode active | `playwright-cli click <ref of "SELECT" button>` | SELECT button shows `.active` |
+| 2 | Click a note on canvas | `playwright-cli click <ref of canvas.storming-canvas>` | Note selected (visual highlight) |
+| 3 | Press Delete | `playwright-cli press Delete` | Note removed; count decrements |
 
 ### Move Notes (SELECT Mode)
 
 **Precondition**: On board page with at least 1 note, SELECT mode active
 
-To move a note, use `run_playwright_code` to perform a mousedown→drag→mouseup on the canvas. You must first retrieve the note's world coordinates to calculate correct viewport positions.
+To move a note, use `playwright-cli eval` and mouse commands to perform a mousedown→drag→mouseup on the canvas. You must first retrieve the note's world coordinates to calculate correct viewport positions.
 
 #### Step 1: Get Note Positions
 
-```js
-// run_playwright_code: retrieve note world coords and canvas transform
-const result = await page.evaluate(`
-  (function() {
-    var ng = window.ng;
-    var bc = document.querySelector('app-board-canvas');
-    var comp = ng.getComponent(bc);
-    var svc = comp.canvasService;
-    var notes = svc.boardState.notes;
-    return JSON.stringify({
-      originX: svc.originX, originY: svc.originY, scale: svc.scale,
-      notes: notes.map(function(n) {
-        return { type: n.type, text: n.text, x: n.x, y: n.y, w: n.width, h: n.height };
-      })
-    });
-  })()
-`);
-return result;
+> **⚠ IIFE syntax fails in `playwright-cli eval`**: Wrapping code in `(() => { ... })()` causes a `TypeError: result is not a function` error. Access properties individually or use simple expressions instead.
+
+```bash
+# Get canvas transform and note count
+playwright-cli eval "window.ng.getComponent(document.querySelector('app-board-canvas')).canvasService.scale"
+playwright-cli eval "window.ng.getComponent(document.querySelector('app-board-canvas')).canvasService.originX"
+playwright-cli eval "window.ng.getComponent(document.querySelector('app-board-canvas')).canvasService.originY"
+playwright-cli eval "window.ng.getComponent(document.querySelector('app-board-canvas')).canvasService.boardState.notes.length"
+# Get individual note coords (index 0, 1, etc.)
+playwright-cli eval "window.ng.getComponent(document.querySelector('app-board-canvas')).canvasService.boardState.notes[0].x"
+playwright-cli eval "window.ng.getComponent(document.querySelector('app-board-canvas')).canvasService.boardState.notes[0].y"
+playwright-cli eval "window.ng.getComponent(document.querySelector('app-board-canvas')).canvasService.boardState.notes[0].width + '/' + window.ng.getComponent(document.querySelector('app-board-canvas')).canvasService.boardState.notes[0].height"
+# Get canvas bounding box (note: canvases uses x:0, y:48 in default viewport)
+playwright-cli eval "JSON.stringify(document.querySelector('canvas.storming-canvas').getBoundingClientRect())"
 ```
+
+Viewport formula: `vpX = canvasBox.x + (worldX * scale) + originX`, `vpY = canvasBox.y + (worldY * scale) + originY`.
 
 #### Step 2: Drag the Note
 
 Convert world-coords to viewport: `vpX = canvasBox.x + (worldX * scale) + originX`, `vpY = canvasBox.y + (worldY * scale) + originY`.
 
-```js
-// run_playwright_code: drag note from current center to new position
-const canvas = page.locator('canvas.storming-canvas');
-const box = await canvas.boundingBox();
-// Example: move note from world center (200,160) by 300px right
-const fromVpX = box.x + 200;
-const fromVpY = box.y + 160;
-const toVpX = fromVpX + 300;
-const toVpY = fromVpY;
-await page.mouse.move(fromVpX, fromVpY);
-await page.mouse.down();
-for (let i = 1; i <= 20; i++) {
-  await page.mouse.move(
-    fromVpX + (toVpX - fromVpX) * (i / 20),
-    fromVpY + (toVpY - fromVpY) * (i / 20)
-  );
-}
-await page.mouse.up();
+Use `playwright-cli mousemove`, `playwright-cli mousedown`, and `playwright-cli mouseup` for the drag:
+
+```bash
+# Move to note center, mousedown, drag in steps, mouseup
+playwright-cli mousemove <fromVpX> <fromVpY>
+playwright-cli mousedown
+# Move in increments to the destination
+playwright-cli mousemove <toVpX> <toVpY>
+playwright-cli mouseup
+```
+
+For smoother drags (required for canvas to register movement), use `playwright-cli eval`:
+
+```bash
+playwright-cli eval "async (page) => { const canvas = document.querySelector('canvas.storming-canvas'); const box = canvas.getBoundingClientRect(); /* calculate fromVpX/Y and toVpX/Y from world coords */ }"
 ```
 
 **Important**: The note must be clicked first (single click in SELECT mode) to select it before dragging. A cyan selection border appears when selected. If the note is already under the cursor at mousedown, the drag will move it.
@@ -285,45 +289,42 @@ await page.mouse.up();
 
 **Precondition**: On board page with at least 2 notes
 
+> **⚠ Notes spawn close together**: Sequential note creation places notes at nearly the same world position (e.g. (140,100) and (150,110)), causing them to overlap. **Move the second note at least 300px to the right before drawing a connection**, otherwise the mousedown and mouseup land inside the same note and no connection is created.
+
 ### Steps
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click DRAW button | `click_element(element="DRAW button")` | DRAW button active (`[active]` state); toast "Draw Connection" appears |
-| 2 | mousedown on source note → drag → mouseup on target note | `run_playwright_code` (see below) | Connection arrow drawn between notes |
-| 3 | Verify connection count | Read status bar | Connection count increments (e.g. "1 CONNECTIONS") |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 0 | Get note positions | Use individual property evals (see Step 1 below) | Know world coords of both notes |
+| 0b | Switch to SELECT mode | `playwright-cli click <ref of "SELECT" button>` | SELECT button active |
+| 0c | Move second note right | mousedown on note[1] center → drag 300+ px right → mouseup (see Move Notes in Journey 3) | Notes are now clearly separated |
+| 1 | Click DRAW button | `playwright-cli click <ref of "DRAW" button>` | DRAW button active (`[active]` state); toast "Draw Connection" appears |
+| 2 | mousedown on source note → drag → mouseup on target note | `playwright-cli mousemove`/`mousedown`/`mouseup` (see below) | Connection arrow drawn between notes |
+| 3 | Verify connection count | `playwright-cli snapshot` and read status bar | Connection count increments (e.g. "1 CONNECTIONS") |
 
-### Drawing a Connection with Playwright
+### Drawing a Connection with Playwright CLI
 
-Connection drawing requires `run_playwright_code` because notes are on an HTML Canvas, not DOM elements. You must mousedown **inside** the source note and mouseup **inside** the target note — start dragging immediately from mousedown.
+Connection drawing requires coordinate-based mouse commands because notes are on an HTML Canvas, not DOM elements. You must mousedown **inside** the source note and mouseup **inside** the target note — start dragging immediately from mousedown.
 
 **Do NOT double-click** — double-clicking a note opens the "Edit Note Text" dialog, even in DRAW mode.
 
-#### Step 1: Get Note Positions (same as Move Notes above)
+#### Step 1: Get Note Positions (same as Move Notes above — use individual property evals, not IIFE)
 
 #### Step 2: Draw the Connection
 
-```js
-// run_playwright_code: draw connection from Event note to Command note
-const canvas = page.locator('canvas.storming-canvas');
-const box = await canvas.boundingBox();
-// World coords → viewport: vpX = box.x + worldX, vpY = box.y + worldY (when scale=1, origin=0,0)
-// Source note center (e.g. Event at world 200,160)
-const fromVpX = box.x + 200;
-const fromVpY = box.y + 160;
-// Target note center (e.g. Command at world 510,171)
-const toVpX = box.x + 510;
-const toVpY = box.y + 171;
-// Immediate mousedown → drag → mouseup
-await page.mouse.move(fromVpX, fromVpY);
-await page.mouse.down();
-for (let i = 1; i <= 20; i++) {
-  await page.mouse.move(
-    fromVpX + (toVpX - fromVpX) * (i / 20),
-    fromVpY + (toVpY - fromVpY) * (i / 20)
-  );
-}
-await page.mouse.up();
+```bash
+# Get canvas bounding box and note positions first via eval
+# Then draw connection from source to target note centers:
+playwright-cli mousemove <sourceVpX> <sourceVpY>
+playwright-cli mousedown
+playwright-cli mousemove <targetVpX> <targetVpY>
+playwright-cli mouseup
+```
+
+For smoother drags with incremental mouse moves, use `playwright-cli eval`:
+
+```bash
+playwright-cli eval "async () => { const canvas = document.querySelector('canvas.storming-canvas'); const box = canvas.getBoundingClientRect(); /* calculate source/target viewport coords, then use mouse.move/down/up */ }"
 ```
 
 **Key points**:
@@ -342,12 +343,12 @@ await page.mouse.up();
 
 ### Steps
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click AI button in toolbar | `click_element(element="AI button")` | AI chat panel opens on right side |
-| 2 | Type message | `type_in_page(ref=<textbox "Ask the AI assistant...">, text="Add an OrderPlaced event")` | Text appears in input |
-| 3 | Send message | `type_in_page(key="Enter")` or click send button | Message sent; AI response streams in |
-| 4 | Close panel | Click close button (X icon) or click AI button again | Panel closes |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Click AI button in toolbar | `playwright-cli click <ref of "AI" button>` | AI chat panel opens on right side |
+| 2 | Type message | `playwright-cli fill <ref of "Ask the AI assistant..." textbox> "Add an OrderPlaced event"` | Text appears in input |
+| 3 | Send message | `playwright-cli press Enter` or click send button ref | Message sent; AI response streams in |
+| 4 | Close panel | Click close button (X icon) ref or click AI button again | Panel closes |
 
 ### AI Chat Panel Structure
 
@@ -382,14 +383,14 @@ generic (chat container)
 
 ### Steps
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click psychology icon (Board Context) | `click_element(element="Board Context button")` with `psychology` icon | "Board Context for AI" dialog opens |
-| 2 | Fill Domain | `type_in_page(ref=<textbox "Domain">, text="eCommerce marketplace")` | Domain entered |
-| 3 | Fill Session Scope | `type_in_page(ref=<textbox "Session Scope">, text="Order fulfillment")` | Scope entered |
-| 4 | Select Workshop Phase | `click_element(ref=<combobox "Workshop Phase">)` then select phase option | Phase selected |
-| 5 | *(Optional)* Toggle autonomous mode | `click_element(ref=<switch "Run the AI facilitator autonomously">)` | Toggle switches on/off |
-| 6 | Click Save | `click_element(element="Save button")` | Dialog closes; changes applied |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Click psychology icon (Board Context) | `playwright-cli click <ref of psychology icon button>` | "Board Context for AI" dialog opens |
+| 2 | Fill Domain | `playwright-cli fill <ref of "Domain" textbox> "eCommerce marketplace"` | Domain entered |
+| 3 | Fill Session Scope | `playwright-cli fill <ref of "Session Scope" textbox> "Order fulfillment"` | Scope entered |
+| 4 | Select Workshop Phase | `playwright-cli click <ref of "Workshop Phase" combobox>` then click phase option ref | Phase selected |
+| 5 | *(Optional)* Toggle autonomous mode | `playwright-cli click <ref of "Run the AI facilitator autonomously" switch>` | Toggle switches on/off |
+| 6 | Click Save | `playwright-cli click <ref of "Save" button>` | Dialog closes; changes applied |
 
 ### Dialog Structure
 
@@ -420,14 +421,14 @@ dialog "Board Context for AI"
 
 ### Steps
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click smart_toy icon (Agent Config) | `click_element(element="Agent Config button")` with `smart_toy` icon | "Configure AI Agents" dialog opens |
-| 2 | View agent list | Read dialog | Lists: Facilitator, EventExplorer, TriggerMapper, DomainDesigner, Organiser, DomainExpert |
-| 3 | Expand an agent | `click_element(element="EventExplorer agent row")` | Agent config form expands |
-| 4 | Edit agent fields | Modify Name, Model, System Prompt, etc. | Fields update |
-| 5 | Switch to interaction diagram | Click hub icon tab button | Diagram shows agent communication graph |
-| 6 | Click Save | `click_element(element="Save button")` | Dialog closes; agent configs saved |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Click smart_toy icon (Agent Config) | `playwright-cli click <ref of smart_toy icon button>` | "Configure AI Agents" dialog opens |
+| 2 | View agent list | `playwright-cli snapshot` | Lists: Facilitator, EventExplorer, TriggerMapper, DomainDesigner, Organiser, DomainExpert |
+| 3 | Expand an agent | `playwright-cli click <ref of "EventExplorer" agent row>` | Agent config form expands |
+| 4 | Edit agent fields | Modify Name, Model, System Prompt, etc. via `fill`/`click`/`select` | Fields update |
+| 5 | Switch to interaction diagram | `playwright-cli click <ref of hub icon tab>` | Diagram shows agent communication graph |
+| 6 | Click Save | `playwright-cli click <ref of "Save" button>` | Dialog closes; agent configs saved |
 
 ### Dialog Structure — Config Tab
 
@@ -476,24 +477,42 @@ dialog "Configure AI Agents"
 
 ## Journey 8: Export and Import Board
 
-### Export as JSON
+**⚠ Export buttons trigger OS-level file dialogs that cannot be dismissed by browser automation.** Do NOT click the export buttons during automated regression testing — this will leave a Save-As dialog open and block all subsequent journeys.
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click download icon | `click_element(element="Export as JSON button")` with `download` icon | Browser downloads `.json` file |
+### Automated Testing Strategy
 
-### Export as Image
+For regression testing, **verify only that the export buttons exist and are enabled** — do not click them:
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click image icon | `click_element(element="Export as Image button")` with `image` icon | Browser downloads `.png` file |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Verify Export as JSON button exists | `playwright-cli snapshot` and check for `download` icon button | Button is present and not disabled |
+| 2 | Verify Export as Image button exists | Check snapshot for `image` icon button | Button is present and not disabled |
+| 3 | Verify Import from JSON button exists | Check snapshot for `upload` icon button | Button is present and not disabled |
 
-### Import from JSON
+Mark this journey as **Pass (presence only)** in the regression report and add to "Manual Verification Needed" that actual export/import file operations need manual testing.
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click upload icon | `click_element(element="Import from JSON button")` with `upload` icon | File chooser dialog opens |
-| 2 | Select JSON file | `handle_dialog(selectFiles=["/path/to/board.json"])` | Board state loaded from file |
+### Manual Testing Reference
+
+These steps are for **manual testing only** — do not execute in automated runs:
+
+#### Export as JSON
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Click download icon (`download` icon) | Browser downloads `.json` file |
+
+#### Export as Image
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Click image icon (`image` icon) | Browser downloads `.png` file |
+
+#### Import from JSON
+
+| # | Action | Expected Result |
+|---|--------|-----------------|
+| 1 | Click upload icon (`upload` icon) | File chooser dialog opens |
+| 2 | Select JSON file | Board state loaded from file |
 
 ---
 
@@ -501,11 +520,11 @@ dialog "Configure AI Agents"
 
 **Precondition**: On board page
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click board name input | `click_element(ref=<textbox "Enter board name">)` | Input becomes focused |
-| 2 | Clear and type new name | `type_in_page(key="Control+a")` then `type_in_page(text="New Board Name")` | Name updated |
-| 3 | Click away or press Enter | `type_in_page(key="Enter")` or click elsewhere | Name saved and broadcast |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Click board name input | `playwright-cli click <ref of "Enter board name" textbox>` | Input becomes focused |
+| 2 | Clear and type new name | `playwright-cli press Control+a` then `playwright-cli type "New Board Name"` | Name updated |
+| 3 | Click away or press Enter | `playwright-cli press Enter` or click elsewhere | Name saved and broadcast |
 
 ---
 
@@ -513,13 +532,13 @@ dialog "Configure AI Agents"
 
 **Precondition**: On any page
 
-| # | Action | Tool Call | Expected Result |
-|---|--------|-----------|-----------------|
-| 1 | Click settings gear in nav bar | `click_element(element="settings gear icon")` | Appearance popover opens |
-| 2 | Toggle light/dark switch | `click_element(ref=<switch "Toggle light mode">)` | Theme changes; popover shows "Light"/"Dark" |
-| 3 | Click outside popover | `click_element(selector=".settings-menu-backdrop")` | Popover closes |
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Click settings gear in nav bar | `playwright-cli click <ref of settings icon>` | Appearance popover opens |
+| 2 | Toggle light/dark switch | `playwright-cli click <ref of "Toggle light mode" switch>` | Theme changes; popover shows "Light"/"Dark" |
+| 3 | Click outside popover | `playwright-cli eval "document.querySelector('.settings-menu-backdrop').click()"` | Popover closes |
 
-**Note**: The backdrop must be clicked using a CSS selector (`.settings-menu-backdrop`), not an aria ref. The theme indicator shows icon `dark_mode` + "Dark" or `light_mode` + "Light" depending on current theme.
+**Note**: The backdrop must be clicked using a JS eval with CSS selector (`.settings-menu-backdrop`), not a snapshot ref. The theme indicator shows icon `dark_mode` + "Dark" or `light_mode` + "Light" depending on current theme.
 
 ---
 
@@ -531,6 +550,9 @@ The board canvas is an HTML Canvas element — notes and connections are **not**
 |---------|--------|
 | **Note selection** | Notes are rendered imperatively on canvas; cannot be targeted by DOM selectors |
 | **Note positioning** | Requires coordinate-based mouse events rather than element clicks |
+| **Canvas offset** | The canvas bounding box is `{ x: 0, y: 48 }` in the default viewport (top nav is 48px tall). Always add this offset when converting world coords to viewport coords. |
+| **IIFE in eval fails** | `playwright-cli eval "(() => { ... })()"` causes `TypeError: result is not a function`. Use individual property access expressions instead. |
+| **Note overlap on creation** | Sequential note creation places notes at nearby positions (e.g. (140,100) and (150,110)). For connection testing, create notes in separate steps and verify positions before drawing. |
 | **Double-click to edit** | Double-click on canvas at note coordinates opens the Note Text Modal (DOM dialog) |
 | **Bounded context drawing** | In CONTEXT mode, click-and-drag on canvas creates a rectangle |
 | **Connection drawing** | In DRAW mode, drag from source note to target note on canvas |

--- a/.agent-context/tasks/angular-signals-modernization/phase-1-services-inject.md
+++ b/.agent-context/tasks/angular-signals-modernization/phase-1-services-inject.md
@@ -1,0 +1,164 @@
+# Phase 1: Services — inject() Migration
+
+**Objective**: Convert all 6 Angular services with dependencies from constructor injection to the `inject()` function pattern. (`ThemeService` has no injected dependencies and requires no changes.)
+
+**Files to modify**:
+- `src/eventstormingboard.client/src/app/_shared/services/auth.service.ts` — constructor(MsalService) → inject()
+- `src/eventstormingboard.client/src/app/_shared/services/boards.service.ts` — constructor(HttpClient) → inject()
+- `src/eventstormingboard.client/src/app/_shared/services/boards-signalr.service.ts` — constructor(AuthService) → inject()
+- `src/eventstormingboard.client/src/app/_shared/services/user.service.ts` — constructor(AuthService) → inject()
+- `src/eventstormingboard.client/src/app/_shared/services/icons.service.ts` — constructor(MatIconRegistry, DomSanitizer) → inject()
+- `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts` — constructor(BoardsSignalRService) → inject()
+
+## Context
+
+Services are the foundation — components depend on them. Converting services first ensures the injection pattern is modernized before touching components. All services use `@Injectable({ providedIn: 'root' })` (except `BoardCanvasService` which is `@Injectable()` with component-level providers). `ThemeService` has no injected dependencies and is excluded from this phase.
+
+## Knowledge, Instructions & Skills
+
+- `.github/instructions/angular.instructions.md` — Defines the `inject()` convention for DI
+
+## Implementation Steps
+
+### Step 1: Convert AuthService
+
+Replace constructor injection with `inject()`. The `MsalService | null` optional injection requires special handling — use `inject(MsalService, { optional: true })`.
+
+**Current code:**
+```typescript
+constructor(private msalService: MsalService | null) {
+    this._initialized$.next();
+}
+```
+
+**Target code:**
+```typescript
+private msalService = inject(MsalService, { optional: true });
+
+constructor() {
+    this._initialized$.next();
+}
+```
+
+Note: `inject(MsalService, { optional: true })` returns `MsalService | null`
+
+Add `import { inject } from '@angular/core';` to the imports.
+
+**Reference**: `src/eventstormingboard.client/src/app/_shared/services/auth.service.ts`
+
+### Step 2: Convert BoardsService
+
+Simple single-injection conversion.
+
+**Current:**
+```typescript
+constructor(private http: HttpClient) {}
+```
+
+**Target:**
+```typescript
+private http = inject(HttpClient);
+```
+
+Remove the constructor entirely. Add `inject` to imports from `@angular/core`.
+
+**Reference**: `src/eventstormingboard.client/src/app/_shared/services/boards.service.ts`
+
+### Step 3: Convert BoardsSignalRService
+
+The constructor has logic that calls `this.initConnection()`.
+
+**Current:**
+```typescript
+constructor(private authService: AuthService) {
+    this.connectionEstablished = this.initConnection();
+}
+```
+
+**Target:**
+```typescript
+private authService = inject(AuthService);
+private connectionEstablished = this.initConnection();
+```
+
+Remove the constructor. The `connectionEstablished` field initializer calls `initConnection()` which may reference `this.authService` — since field initializers execute in declaration order and `authService` is declared first, this is safe.
+
+**Reference**: `src/eventstormingboard.client/src/app/_shared/services/boards-signalr.service.ts`
+
+### Step 4: Convert UserService
+
+The constructor has logic that checks auth and overrides the username.
+
+**Current:**
+```typescript
+constructor(private authService: AuthService) {
+    if (this.authService.isAuthEnabled) {
+      const authName = this.authService.getUserName();
+      if (authName) {
+        this.userName$.next(authName);
+      }
+    }
+}
+```
+
+**Target:**
+```typescript
+private authService = inject(AuthService);
+
+constructor() {
+    if (this.authService.isAuthEnabled) {
+      const authName = this.authService.getUserName();
+      if (authName) {
+        this.userName$.next(authName);
+      }
+    }
+}
+```
+
+Keep the constructor for the init logic. Add `inject` to imports.
+
+**Reference**: `src/eventstormingboard.client/src/app/_shared/services/user.service.ts`
+
+### Step 5: Convert IconsService
+
+**Current:**
+```typescript
+constructor(private iconRegistry: MatIconRegistry, private sanitizer: DomSanitizer) {}
+```
+
+**Target:**
+```typescript
+private iconRegistry = inject(MatIconRegistry);
+private sanitizer = inject(DomSanitizer);
+```
+
+Remove the constructor. Add `inject` to imports from `@angular/core`.
+
+**Reference**: `src/eventstormingboard.client/src/app/_shared/services/icons.service.ts`
+
+### Step 6: Convert BoardCanvasService
+
+**Current:**
+```typescript
+constructor(
+    private boardsHub: BoardsSignalRService
+) {
+}
+```
+
+**Target:**
+```typescript
+private boardsHub = inject(BoardsSignalRService);
+```
+
+Remove the empty constructor. Add `inject` to imports from `@angular/core`.
+
+**Reference**: `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts`
+
+## Verification Criteria
+
+- [ ] `cd src/eventstormingboard.client && npm run build` passes with no errors
+- [ ] All 6 services with dependencies use `inject()` for DI (no `private x: Type` in constructors)
+- [ ] Constructors only remain where they contain initialization logic
+- [ ] `inject` is imported from `@angular/core` in all modified files
+- [ ] `ThemeService` is unchanged (no dependencies to inject)

--- a/.agent-context/tasks/angular-signals-modernization/phase-2-simple-components-inject.md
+++ b/.agent-context/tasks/angular-signals-modernization/phase-2-simple-components-inject.md
@@ -1,0 +1,205 @@
+# Phase 2: Simple Components — inject() Migration
+
+**Objective**: Convert all 7 simple modal/leaf components from constructor injection (including `@Inject()` decorator) to the `inject()` function.
+
+**Files to modify**:
+- `src/eventstormingboard.client/src/app/board/board-canvas/bc-name-modal/bc-name-modal.component.ts` — @Inject(MAT_DIALOG_DATA) + MatDialogRef
+- `src/eventstormingboard.client/src/app/board/board-canvas/note-text-modal/note-text-modal.component.ts` — @Inject(MAT_DIALOG_DATA) + MatDialogRef
+- `src/eventstormingboard.client/src/app/board/keyboard-shortcuts-modal/keyboard-shortcuts-modal.component.ts` — MatDialogRef
+- `src/eventstormingboard.client/src/app/board/board-context-modal/board-context-modal.component.ts` — @Inject(MAT_DIALOG_DATA) + MatDialogRef
+- `src/eventstormingboard.client/src/app/splash/select-board-modal/select-board-modal.component.ts` — @Inject(MAT_DIALOG_DATA) + MatDialogRef + BoardsService
+- `src/eventstormingboard.client/src/app/splash/create-board-modal/create-board-modal.component.ts` — @Inject(MAT_DIALOG_DATA) + MatDialogRef + BoardsService
+- `src/eventstormingboard.client/src/app/board/agent-config-modal/agent-config-modal.component.ts` — @Inject(MAT_DIALOG_DATA) + MatDialogRef + BoardsService
+
+## Context
+
+These are leaf components (modals and simple views) with no child components that need signal I/O. They only require converting `constructor(... @Inject(MAT_DIALOG_DATA) ...)` to `inject()`. Template bindings to `dialogRef` and `data` continue to work since they become regular class properties.
+
+**Critical**: Several of these components use `public dialogRef` and `public data` which are referenced directly in templates (e.g., `(click)="dialogRef.close()"`, `[(ngModel)]="data.name"`). The `inject()` conversion must keep these as `public` (or at minimum non-private) fields.
+
+## Knowledge, Instructions & Skills
+
+- `.github/instructions/angular.instructions.md` — `inject()` convention: `inject(MAT_DIALOG_DATA)`, `inject(ActivatedRoute)`
+
+## Implementation Steps
+
+### Step 1: Convert BcNameModalComponent
+
+**Current:**
+```typescript
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+// ...
+
+export class BcNameModalComponent {
+  constructor(
+    public dialogRef: MatDialogRef<BcNameModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { name: string }
+  ) {}
+```
+
+**Target:**
+```typescript
+import { Component, inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+// ...
+
+export class BcNameModalComponent {
+  public dialogRef = inject<MatDialogRef<BcNameModalComponent>>(MatDialogRef);
+  public data = inject<{ name: string }>(MAT_DIALOG_DATA);
+```
+
+Remove `Inject` from the `@angular/core` import, add `inject`. Remove the constructor entirely.
+
+### Step 2: Convert NoteTextModalComponent
+
+Identical pattern to BcNameModalComponent.
+
+**Target:**
+```typescript
+import { Component, inject } from '@angular/core';
+// ...
+export class NoteTextModalComponent {
+  public dialogRef = inject<MatDialogRef<NoteTextModalComponent>>(MatDialogRef);
+  public data = inject<{ text: string }>(MAT_DIALOG_DATA);
+```
+
+### Step 3: Convert KeyboardShortcutsModalComponent
+
+This one only has `MatDialogRef`, no `MAT_DIALOG_DATA`.
+
+**Current:**
+```typescript
+constructor(public dialogRef: MatDialogRef<KeyboardShortcutsModalComponent>) {}
+```
+
+**Target:**
+```typescript
+public dialogRef = inject<MatDialogRef<KeyboardShortcutsModalComponent>>(MatDialogRef);
+```
+
+Remove `Component` from needing changes, add `inject` to `@angular/core` import. Remove constructor.
+
+### Step 4: Convert BoardContextModalComponent
+
+**Current:**
+```typescript
+import { Component, Inject } from '@angular/core';
+// ...
+export class BoardContextModalComponent {
+  public phases = EVENT_STORMING_PHASES;
+
+  constructor(
+    public dialogRef: MatDialogRef<BoardContextModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: BoardContextData
+  ) { }
+```
+
+**Target:**
+```typescript
+import { Component, inject } from '@angular/core';
+// ...
+export class BoardContextModalComponent {
+  public phases = EVENT_STORMING_PHASES;
+  public dialogRef = inject<MatDialogRef<BoardContextModalComponent>>(MatDialogRef);
+  public data = inject<BoardContextData>(MAT_DIALOG_DATA);
+```
+
+### Step 5: Convert SelectBoardModalComponent
+
+Has `@Inject(MAT_DIALOG_DATA)` plus `BoardsService` injection. Also implements `OnInit`.
+
+**Current:**
+```typescript
+import { Component, Inject, OnInit } from '@angular/core';
+// ...
+export class SelectBoardModalComponent implements OnInit {
+  boards: BoardSummaryDto[] = [];
+  selectedBoardId: string | null = null;
+
+  constructor(
+    public dialogRef: MatDialogRef<SelectBoardModalComponent>,
+    private boardsService: BoardsService,
+    @Inject(MAT_DIALOG_DATA) public data: { id: string }
+  ) { }
+```
+
+**Target:**
+```typescript
+import { Component, inject, OnInit } from '@angular/core';
+// ...
+export class SelectBoardModalComponent implements OnInit {
+  public dialogRef = inject<MatDialogRef<SelectBoardModalComponent>>(MatDialogRef);
+  private boardsService = inject(BoardsService);
+  public data = inject<{ id: string }>(MAT_DIALOG_DATA);
+
+  boards: BoardSummaryDto[] = [];
+  selectedBoardId: string | null = null;
+```
+
+Remove `Inject` from imports, add `inject`. Remove constructor.
+
+### Step 6: Convert CreateBoardModalComponent
+
+**Current:**
+```typescript
+import { Component, Inject } from '@angular/core';
+// ...
+export class CreateBoardModalComponent {
+  constructor(
+    public dialogRef: MatDialogRef<CreateBoardModalComponent>,
+    private boardsService: BoardsService,
+    @Inject(MAT_DIALOG_DATA) public data: {
+      name: string;
+      domain?: string;
+      sessionScope?: string;
+    }
+  ) { }
+```
+
+**Target:**
+```typescript
+import { Component, inject } from '@angular/core';
+// ...
+export class CreateBoardModalComponent {
+  public dialogRef = inject<MatDialogRef<CreateBoardModalComponent>>(MatDialogRef);
+  private boardsService = inject(BoardsService);
+  public data = inject<{ name: string; domain?: string; sessionScope?: string }>(MAT_DIALOG_DATA);
+```
+
+### Step 7: Convert AgentConfigModalComponent
+
+Has `@Inject(MAT_DIALOG_DATA)` plus `MatDialogRef` plus `BoardsService`. Implements `OnInit`.
+
+**Current:**
+```typescript
+import { Component, Inject, OnInit } from '@angular/core';
+// ...
+export class AgentConfigModalComponent implements OnInit {
+  // ... fields ...
+  constructor(
+    public dialogRef: MatDialogRef<AgentConfigModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: AgentConfigModalData,
+    private boardsService: BoardsService
+  ) {}
+```
+
+**Target:**
+```typescript
+import { Component, inject, OnInit } from '@angular/core';
+// ...
+export class AgentConfigModalComponent implements OnInit {
+  public dialogRef = inject<MatDialogRef<AgentConfigModalComponent>>(MatDialogRef);
+  public data = inject<AgentConfigModalData>(MAT_DIALOG_DATA);
+  private boardsService = inject(BoardsService);
+  // ... fields ...
+```
+
+## Verification Criteria
+
+- [ ] `cd src/eventstormingboard.client && npm run build` passes with no errors
+- [ ] No `@Inject()` decorator remains in any modal component
+- [ ] No constructor injection in any of the 7 files
+- [ ] `public dialogRef` and `public data` remain accessible for template bindings
+- [ ] `inject` imported from `@angular/core` in all modified files
+- [ ] `MatDialogRef` typed via `inject<MatDialogRef<X>>(MatDialogRef)` pattern (type parameter on `inject`, not instantiation expression)

--- a/.agent-context/tasks/angular-signals-modernization/phase-3-root-splash-signals.md
+++ b/.agent-context/tasks/angular-signals-modernization/phase-3-root-splash-signals.md
@@ -1,0 +1,160 @@
+# Phase 3: Root & Splash — inject() + takeUntilDestroyed()
+
+**Objective**: Convert `AppComponent` and `SplashComponent` from legacy patterns to modern Angular: `inject()` for DI and `takeUntilDestroyed()` for cleanup. (`toSignal()` was considered but is not feasible here — `userName` is two-way bound via `[(ngModel)]` and requires a mutable property.)
+
+**Files to modify**:
+- `src/eventstormingboard.client/src/app/app.component.ts` — inject(), takeUntilDestroyed()
+- `src/eventstormingboard.client/src/app/splash/splash.component.ts` — inject(), takeUntilDestroyed()
+
+## Context
+
+Both components follow the same pattern: constructor injection, `destroy$` Subject + `takeUntil()`, and a simple subscription that maps an observable to a local property. The `userName` property is bound via `[(ngModel)]` for editing, so it must remain a plain mutable property — a readonly `toSignal()` cannot be used with two-way binding. The migration applies `inject()` + `takeUntilDestroyed()` only. No template changes are needed.
+
+## Knowledge, Instructions & Skills
+
+- `.github/instructions/angular.instructions.md` — `inject()`, `takeUntilDestroyed()` conventions
+
+## Implementation Steps
+
+### Step 1: Convert AppComponent
+
+**Current pattern:**
+```typescript
+import { Component, OnDestroy, OnInit } from '@angular/core';
+// ...
+import { Subject, takeUntil } from 'rxjs';
+
+export class AppComponent implements OnInit, OnDestroy {
+  public userName: string = '';
+  private destroy$ = new Subject<void>();
+
+  constructor(private iconsService: IconsService,
+    private router: Router,
+    private userService: UserService,
+    public themeService: ThemeService
+  ) {
+    this.iconsService.registerIcons();
+  }
+
+  public ngOnInit(): void {
+    this.userService.displayName$.pipe(takeUntil(this.destroy$)).subscribe(name => {
+      this.userName = name;
+    });
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+```
+
+**Target:**
+```typescript
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+// ...
+
+export class AppComponent implements OnInit {
+  private iconsService = inject(IconsService);
+  private router = inject(Router);
+  private userService = inject(UserService);
+  public themeService = inject(ThemeService);
+  private destroyRef = inject(DestroyRef);
+
+  public userName: string = '';
+
+  constructor() {
+    this.iconsService.registerIcons();
+  }
+
+  public ngOnInit(): void {
+    this.userService.displayName$.pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(name => {
+      this.userName = name;
+    });
+  }
+```
+
+Changes:
+1. Constructor injection → `inject()` field initializers
+2. Remove `OnDestroy`, `destroy$`, `ngOnDestroy()`
+3. Add `DestroyRef` injection via `inject(DestroyRef)`
+4. Replace `takeUntil(this.destroy$)` with `takeUntilDestroyed(this.destroyRef)`
+5. Keep constructor for `iconsService.registerIcons()` side effect
+6. No template changes needed — `userName` stays a plain mutable property for `[(ngModel)]`
+
+**Reference**: `src/eventstormingboard.client/src/app/app.component.ts` (73 lines)
+
+### Step 2: Convert SplashComponent
+
+**Current pattern:**
+```typescript
+import { Component, OnDestroy, OnInit } from '@angular/core';
+// ...
+import { Subject, takeUntil } from 'rxjs';
+
+export class SplashComponent implements OnInit, OnDestroy {
+  public userName: string = '';
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private router: Router,
+    private dialog: MatDialog,
+    private userService: UserService) { }
+
+  public ngOnInit(): void {
+    this.userService.displayName$.pipe(takeUntil(this.destroy$)).subscribe(name => {
+      this.userName = name;
+    });
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+```
+
+**Target:**
+```typescript
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+// ...
+
+export class SplashComponent implements OnInit {
+  private router = inject(Router);
+  private dialog = inject(MatDialog);
+  private userService = inject(UserService);
+  private destroyRef = inject(DestroyRef);
+
+  public userName: string = '';
+
+  public ngOnInit(): void {
+    this.userService.displayName$.pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(name => {
+      this.userName = name;
+    });
+  }
+```
+
+Changes:
+1. Constructor injection → `inject()`
+2. Remove `OnDestroy`, `destroy$`, `ngOnDestroy()`
+3. Add `DestroyRef` + `takeUntilDestroyed()`
+4. Remove `Subject`, `takeUntil` from rxjs imports
+5. Remove constructor entirely
+
+Same rationale as AppComponent — `userName` is used with `[(ngModel)]` for editing, so keep as plain property. No template changes needed.
+
+**Reference**: `src/eventstormingboard.client/src/app/splash/splash.component.ts` (73 lines)
+
+## Verification Criteria
+
+- [ ] `cd src/eventstormingboard.client && npm run build` passes with no errors
+- [ ] No `destroy$` Subject in AppComponent or SplashComponent
+- [ ] No `ngOnDestroy()` in AppComponent or SplashComponent
+- [ ] `takeUntilDestroyed` imported from `@angular/core/rxjs-interop`
+- [ ] `DestroyRef` injected via `inject(DestroyRef)` in both components
+- [ ] No constructor injection in either component
+- [ ] Templates render correctly (userName binding unchanged)

--- a/.agent-context/tasks/angular-signals-modernization/phase-4-signal-io-components.md
+++ b/.agent-context/tasks/angular-signals-modernization/phase-4-signal-io-components.md
@@ -1,0 +1,310 @@
+# Phase 4: Signal I/O Components — input() + output() + viewChild() + effect()
+
+**Objective**: Convert `AiChatPanelComponent` and `AgentInteractionDiagramComponent` to use signal-based inputs, outputs, view queries, and effects. These are the only components with `@Input()`, `@Output()`, `@ViewChild`, and `OnChanges` patterns.
+
+**Files to modify**:
+- `src/eventstormingboard.client/src/app/board/ai-chat-panel/ai-chat-panel.component.ts` — @Input → input(), @Output → output(), @ViewChild → viewChild(), destroy$ → takeUntilDestroyed(), constructor → inject(), OnChanges → effect()
+- `src/eventstormingboard.client/src/app/board/ai-chat-panel/ai-chat-panel.component.html` — Update input property references to signal call syntax (e.g., `autonomousEnabled` → `autonomousEnabled()`)
+- `src/eventstormingboard.client/src/app/board/agent-interaction-diagram/agent-interaction-diagram.component.ts` — @Input → input(), @ViewChild → viewChild(), OnChanges → effect()
+
+## Context
+
+These two components contain the most diverse set of legacy patterns in the codebase. `AiChatPanelComponent` has 5 `@Input()`, 2 `@Output()`, 1 `@ViewChild`, `destroy$` + `takeUntil`, constructor injection, and `OnChanges`. `AgentInteractionDiagramComponent` has 1 `@Input()`, 1 `@ViewChild`, and `OnChanges`.
+
+**Critical considerations**:
+- When `@Input()` becomes `input()`, all internal reads of the property change from `this.prop` to `this.prop()` (call the signal)
+- `OnChanges` + `SimpleChanges` cannot detect changes on signal inputs — must be replaced with `effect()`
+- Parent templates (`board.component.html`) do NOT need changes — `[propName]="value"` binding syntax works identically with signal inputs
+- Signal `output()` supports `.emit()` just like `EventEmitter`, and `(eventName)="handler()"` template syntax is unchanged
+- `viewChild()` returns a signal that may be `undefined` until the view initializes — use `viewChild<ElementRef>('ref')` and access via `this.ref()?.nativeElement`
+- `effect()` runs immediately when created (unlike `OnChanges` which only fires on binding changes). **Placement rule**: declare `effect()` field initializers AFTER all dependent state fields (e.g., `agentDisplayMap`) to ensure the map is initialized before the first effect run. Alternatively, guard the effect body: `if (!this.agentDisplayMap) return;`
+
+## Knowledge, Instructions & Skills
+
+- `.github/instructions/angular.instructions.md` — Signal input/output/viewChild patterns, effect() usage
+
+## Implementation Steps
+
+### Step 1: Convert AiChatPanelComponent
+
+This is the most complex conversion. Work through each pattern:
+
+#### 1a. Update imports
+
+**Remove** from `@angular/core`:
+- `EventEmitter`, `Input`, `Output`, `ViewChild`, `OnChanges`, `SimpleChanges`
+
+**Add** to `@angular/core`:
+- `inject`, `input`, `output`, `viewChild`, `effect`, `DestroyRef`, `ElementRef`
+
+**Add** new import:
+- `import { takeUntilDestroyed } from '@angular/core/rxjs-interop';`
+
+**Remove** from `rxjs`:
+- `Subject`, `takeUntil`
+
+#### 1b. Convert class declaration
+
+**Remove** `OnChanges` from `implements` clause. Keep `OnInit`, `OnDestroy` → actually remove `OnDestroy` too since we're removing `destroy$`.
+
+**Current:**
+```typescript
+export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
+```
+
+**Target:**
+```typescript
+export class AiChatPanelComponent implements OnInit {
+```
+
+#### 1c. Convert @Input to input()
+
+**Current:**
+```typescript
+@Input() boardId!: string;
+@Input() userName!: string;
+@Input() autonomousEnabled = false;
+@Input() autonomousStatus?: AutonomousFacilitatorStatus;
+@Input() agentConfigurations: AgentConfiguration[] = [];
+```
+
+**Target:**
+```typescript
+readonly boardId = input.required<string>();
+readonly userName = input.required<string>();
+readonly autonomousEnabled = input(false);
+readonly autonomousStatus = input<AutonomousFacilitatorStatus | undefined>();
+readonly agentConfigurations = input<AgentConfiguration[]>([]);
+```
+
+#### 1d. Convert @Output to output()
+
+**Current:**
+```typescript
+@Output() closed = new EventEmitter<void>();
+@Output() disableAutonomousRequested = new EventEmitter<void>();
+```
+
+**Target:**
+```typescript
+readonly closed = output<void>();
+readonly disableAutonomousRequested = output<void>();
+```
+
+Template usage like `(closed)="..."` and `closed.emit()` and `disableAutonomousRequested.emit()` remains unchanged.
+
+#### 1e. Convert @ViewChild to viewChild()
+
+**Current:**
+```typescript
+@ViewChild('messagesContainer') private messagesContainer!: ElementRef<HTMLDivElement>;
+```
+
+**Target:**
+```typescript
+private messagesContainer = viewChild<ElementRef<HTMLDivElement>>('messagesContainer');
+```
+
+Update the `scrollToBottom()` method:
+**Current:**
+```typescript
+private scrollToBottom(): void {
+    setTimeout(() => {
+      const el = this.messagesContainer?.nativeElement;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+}
+```
+
+**Target:**
+```typescript
+private scrollToBottom(): void {
+    setTimeout(() => {
+      const el = this.messagesContainer()?.nativeElement;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+}
+```
+
+#### 1f. Convert constructor injection to inject()
+
+**Current:**
+```typescript
+constructor(private signalRService: BoardsSignalRService) { }
+```
+
+**Target:**
+```typescript
+private signalRService = inject(BoardsSignalRService);
+private destroyRef = inject(DestroyRef);
+```
+
+Remove the constructor.
+
+#### 1g. Replace OnChanges with effect()
+
+**Current:**
+```typescript
+ngOnChanges(changes: SimpleChanges): void {
+    if (changes['agentConfigurations']) {
+      this.rebuildAgentDisplayMap();
+    }
+}
+```
+
+**Target** — declare AFTER `agentDisplayMap` and other dependent state fields (effect runs immediately on creation):
+```typescript
+private agentConfigEffect = effect(() => {
+    this.agentConfigurations(); // track the signal
+    this.rebuildAgentDisplayMap();
+});
+```
+
+Note: `effect()` runs whenever any signal read inside it changes. Reading `this.agentConfigurations()` establishes the tracking dependency.
+
+**Important**: The `rebuildAgentDisplayMap()` method reads `this.agentConfigurations` — update it to call the signal:
+
+**Current:**
+```typescript
+private rebuildAgentDisplayMap(): void {
+    this.agentDisplayMap.clear();
+    for (const config of this.agentConfigurations) {
+```
+
+**Target:**
+```typescript
+private rebuildAgentDisplayMap(): void {
+    this.agentDisplayMap.clear();
+    for (const config of this.agentConfigurations()) {
+```
+
+#### 1h. Replace destroy$ + takeUntil with takeUntilDestroyed
+
+**Current (in ngOnInit):**
+```typescript
+this.signalRService.agentUserMessage$
+    .pipe(takeUntil(this.destroy$))
+    .subscribe(msg => { ... });
+```
+
+**Target:**
+```typescript
+this.signalRService.agentUserMessage$
+    .pipe(takeUntilDestroyed(this.destroyRef))
+    .subscribe(msg => { ... });
+```
+
+Apply this to all 6 subscription pipes in `ngOnInit()`. Remove the `ngOnDestroy()` method entirely.
+
+#### 1i. Update all internal references to inputs
+
+Every place that reads an input property must add `()`:
+
+- `this.boardId` → `this.boardId()` (used in ngOnInit for getAgentHistory, sendAgentMessage, clearHistory, and in subscription filters)
+- `this.userName` → `this.userName()` (used in `isOwnMessage()` method)
+- `this.autonomousEnabled` → `this.autonomousEnabled()` (used in `autonomousStatusLabel` getter)
+- `this.autonomousStatus` → `this.autonomousStatus()` (used in `autonomousStatusLabel` getter)
+- `this.agentConfigurations` → `this.agentConfigurations()` (used in `rebuildAgentDisplayMap()`)
+
+Search the file exhaustively for all occurrences. Key locations:
+- `ngOnInit()`: `this.boardId` appears multiple times in SignalR calls and event filters
+- `send()`: `this.signalRService.sendAgentMessage(this.boardId, text)`
+- `clearHistory()`: `this.signalRService.clearAgentHistory(this.boardId)`
+- `isOwnMessage()`: `msg.userName === this.userName`
+- `autonomousStatusLabel` getter: reads `this.autonomousEnabled` and `this.autonomousStatus`
+
+#### 1j. Update template references
+
+Check `ai-chat-panel.component.html` for direct references to input properties. In the template:
+- `autonomousEnabled` → `autonomousEnabled()` (in `@if` conditions and bindings)
+- `autonomousStatus?.isRunning` → `autonomousStatus()?.isRunning`
+- `disableAutonomousRequested.emit()` — this stays as-is (output signals support `.emit()`)
+- `closed.emit()` — stays as-is
+
+Search the template file for all usages of the 5 input names and update to signal call syntax.
+
+### Step 2: Convert AgentInteractionDiagramComponent
+
+#### 2a. Update imports
+
+**Remove** from `@angular/core`: `Input`, `OnChanges`, `SimpleChanges`, `ViewChild`
+**Add** to `@angular/core`: `input`, `viewChild`, `effect`, `ElementRef` (keep if not already imported)
+
+#### 2b. Convert class declaration
+
+**Current:**
+```typescript
+export class AgentInteractionDiagramComponent implements OnChanges, AfterViewInit {
+```
+
+**Target:**
+```typescript
+export class AgentInteractionDiagramComponent implements AfterViewInit {
+```
+
+#### 2c. Convert @Input to input()
+
+**Current:**
+```typescript
+@Input() agents: AgentConfiguration[] = [];
+```
+
+**Target:**
+```typescript
+readonly agents = input<AgentConfiguration[]>([]);
+```
+
+#### 2d. Convert @ViewChild to viewChild()
+
+**Current:**
+```typescript
+@ViewChild('diagramContainer') containerRef!: ElementRef<HTMLDivElement>;
+```
+
+**Target:**
+```typescript
+readonly containerRef = viewChild<ElementRef<HTMLDivElement>>('diagramContainer');
+```
+
+#### 2e. Replace OnChanges with effect()
+
+**Current:**
+```typescript
+ngOnChanges(changes: SimpleChanges): void {
+    if (changes['agents']) {
+      this.buildGraph();
+    }
+}
+```
+
+**Target:**
+```typescript
+private agentsEffect = effect(() => {
+    this.agents(); // track signal
+    this.buildGraph();
+});
+```
+
+#### 2f. Update all internal references
+
+- `this.agents` → `this.agents()` everywhere (in `buildGraph()`, `layoutNodes()`, `deriveEdges()`)
+- `this.containerRef` → `this.containerRef()` (in `recalcSize()`, `ngAfterViewInit()`)
+
+Specific locations:
+- `recalcSize()`: `if (this.containerRef)` → `const ref = this.containerRef(); if (ref)`
+- `ngAfterViewInit()`: no direct reference to containerRef here (calls `recalcSize()`)
+- `buildGraph()`: `if (!this.agents || this.agents.length === 0)` → `const agents = this.agents(); if (!agents || agents.length === 0)`
+- `layoutNodes()`: `this.agents.find(...)` → `this.agents().find(...)`
+- `deriveEdges()`: `this.agents.filter(...)`, `this.agents.map(...)` → `this.agents().filter(...)`, etc.
+- `getNode()`, `edgePath()`, etc. — these don't reference `this.agents` directly
+
+## Verification Criteria
+
+- [ ] `cd src/eventstormingboard.client && npm run build` passes with no errors
+- [ ] No `@Input()`, `@Output()`, `@ViewChild` decorators remain in either component
+- [ ] No `EventEmitter` in AiChatPanelComponent
+- [ ] No `destroy$` Subject or `ngOnDestroy` in AiChatPanelComponent
+- [ ] No `OnChanges` or `SimpleChanges` in either component
+- [ ] `effect()` used to react to input signal changes in both components
+- [ ] Parent template `board.component.html` — property bindings `[boardId]`, `[userName]`, etc. still compile (no changes needed)
+- [ ] `agent-config-modal.component.html` — `[agents]` binding on `<app-agent-interaction-diagram>` still compiles

--- a/.agent-context/tasks/angular-signals-modernization/phase-5-large-components.md
+++ b/.agent-context/tasks/angular-signals-modernization/phase-5-large-components.md
@@ -1,0 +1,294 @@
+# Phase 5: Large Components — inject() + viewChild() + takeUntilDestroyed()
+
+**Objective**: Convert `BoardCanvasComponent` (1,976 lines) and `BoardComponent` (995 lines) — the two largest components — from constructor injection, `@ViewChild` decorators, and `destroy$` patterns to modern Angular equivalents.
+
+**Files to modify**:
+- `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts` — inject(), viewChild(), takeUntilDestroyed()
+- `src/eventstormingboard.client/src/app/board/board.component.ts` — inject(), takeUntilDestroyed()
+
+## Context
+
+These are the largest files in the frontend. `BoardCanvasComponent` has 2 `@ViewChild` (static), constructor injection (5 deps), and `destroy$` with 3 subscriptions. `BoardComponent` has constructor injection (6 deps) and `destroy$` with 16+ subscriptions.
+
+**Strategy**: Apply only the mechanical inject/viewChild/takeUntilDestroyed transformations. Do NOT attempt to convert local state variables to signals or restructure subscriptions — these files are too large for invasive refactoring in a single phase.
+
+**Key risk**: `BoardCanvasComponent` uses `@ViewChild('canvas', { static: true })` for canvas elements. Signal `viewChild.required()` has no `static` option — it always behaves like `{ static: false }`, resolving after the view initializes. Since the existing code accesses canvas elements in `ngAfterViewInit → generateCanvas()`, the timing is compatible. The `viewChild.required()` signal will be set by the time `ngAfterViewInit` runs. Verify canvas init still works after migration.
+
+## Knowledge, Instructions & Skills
+
+- `.github/instructions/angular.instructions.md` — `inject()`, `viewChild()`, `takeUntilDestroyed()` conventions
+
+## Implementation Steps
+
+### Step 1: Convert BoardCanvasComponent
+
+#### 1a. Update imports
+
+**Remove** from `@angular/core`: `ViewChild`
+**Add** to `@angular/core`: `inject`, `viewChild`, `DestroyRef`
+**Add**: `import { takeUntilDestroyed } from '@angular/core/rxjs-interop';`
+**Remove** from `rxjs`: `Subject`, `takeUntil`
+
+Keep `AfterViewInit`, `Component`, `ElementRef`, `HostListener`, `OnDestroy`, `OnInit`. Actually, remove `OnDestroy` since we're removing `destroy$` and `ngOnDestroy`.
+
+Wait — `OnDestroy` may be removed IF the only thing in `ngOnDestroy` is `destroy$.next()` + `destroy$.complete()`. Let's check:
+
+```typescript
+public ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+}
+```
+
+Yes, that's all. So remove `OnDestroy` from `implements` and the `ngOnDestroy()` method.
+
+#### 1b. Convert @ViewChild to viewChild()
+
+**Current:**
+```typescript
+@ViewChild('canvas', { static: true })
+public canvas!: ElementRef<HTMLCanvasElement>;
+
+@ViewChild('minimap', { static: true })
+public minimap!: ElementRef<HTMLCanvasElement>;
+```
+
+**Target:**
+```typescript
+public canvas = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
+public minimap = viewChild.required<ElementRef<HTMLCanvasElement>>('minimap');
+```
+
+Using `viewChild.required()` because these elements are always present (static template elements). The signal resolves after view init (no `static` option exists for signal queries). The signal returns `ElementRef<HTMLCanvasElement>` directly (not `undefined`). Only access from `ngAfterViewInit` onward.
+
+#### 1c. Update all canvas/minimap references
+
+Every reference to `this.canvas.nativeElement` must become `this.canvas().nativeElement`, and similarly for `this.minimap.nativeElement` → `this.minimap().nativeElement`.
+
+These are used extensively throughout the 1,976-line file. Key locations include:
+- `onMinimapClick()`: `this.minimap.nativeElement.getBoundingClientRect()`
+- `generateCanvas()`: `this.ctx = this.canvas.nativeElement.getContext('2d')!`
+- `onResize()`: `this.canvas.nativeElement.width = window.innerWidth`
+- `drawCanvas()`: numerous `this.canvas.nativeElement` references
+- `getMousePos()`: `this.canvas.nativeElement.getBoundingClientRect()`
+- All mouse event handlers accessing canvas dimensions
+- Minimap rendering methods
+
+**Search pattern**: Find all occurrences of `this.canvas.nativeElement` and `this.minimap.nativeElement` in the file and add `()` after `canvas`/`minimap`.
+
+Also search for any bare `this.canvas` or `this.minimap` references that don't chain `.nativeElement` (e.g., passed as arguments).
+
+#### 1d. Convert constructor injection to inject()
+
+**Current:**
+```typescript
+constructor(
+    private dialog: MatDialog,
+    private canvasService: BoardCanvasService,
+    private boardsHub: BoardsSignalRService,
+    private themeService: ThemeService,
+    private userService: UserService
+) {
+}
+```
+
+**Target:**
+```typescript
+private dialog = inject(MatDialog);
+private canvasService = inject(BoardCanvasService);
+private boardsHub = inject(BoardsSignalRService);
+private themeService = inject(ThemeService);
+private userService = inject(UserService);
+private destroyRef = inject(DestroyRef);
+```
+
+Remove the empty constructor.
+
+#### 1e. Replace destroy$ + takeUntil with takeUntilDestroyed
+
+**Current (in ngOnInit):**
+```typescript
+this.canvasService.canvasUpdated$
+    .pipe(takeUntil(this.destroy$))
+    .subscribe(() => { this.drawCanvas(); });
+
+this.canvasService.canvasImageDownloaded$
+    .pipe(takeUntil(this.destroy$))
+    .subscribe(() => { this.exportBoardAsImage(); });
+
+this.themeService.theme$
+    .pipe(takeUntil(this.destroy$))
+    .subscribe(() => { if (this.ctx) { this.drawCanvas(); } });
+```
+
+**Target:**
+```typescript
+this.canvasService.canvasUpdated$
+    .pipe(takeUntilDestroyed(this.destroyRef))
+    .subscribe(() => { this.drawCanvas(); });
+
+this.canvasService.canvasImageDownloaded$
+    .pipe(takeUntilDestroyed(this.destroyRef))
+    .subscribe(() => { this.exportBoardAsImage(); });
+
+this.themeService.theme$
+    .pipe(takeUntilDestroyed(this.destroyRef))
+    .subscribe(() => { if (this.ctx) { this.drawCanvas(); } });
+```
+
+Remove `private destroy$ = new Subject<void>();` field and `ngOnDestroy()` method.
+
+#### 1f. Update localUserName getter
+
+**Current:**
+```typescript
+private get localUserName(): string { return this.userService.displayName || 'Anonymous'; }
+```
+
+This doesn't need changes — `userService` is now a field initializer but the getter still works.
+
+### Step 2: Convert BoardComponent
+
+#### 2a. Update imports
+
+**Remove** from `@angular/core`: `OnDestroy` (only if ngOnDestroy has no other logic besides destroy$)
+**Add** to `@angular/core`: `inject`, `DestroyRef`
+**Add**: `import { takeUntilDestroyed } from '@angular/core/rxjs-interop';`
+**Remove** from `rxjs`: `Subject`, `takeUntil`
+
+Check `ngOnDestroy`:
+```typescript
+public ngOnDestroy(): void {
+    this.boardsHub.leaveBoard(this.id);
+    this.canvasService.remoteCursors.clear();
+    this.destroy$.next();
+    this.destroy$.complete();
+}
+```
+
+**Important**: `ngOnDestroy` has cleanup logic beyond `destroy$` — `leaveBoard()` and `remoteCursors.clear()`. So we must keep `OnDestroy` and `ngOnDestroy()`, but remove the destroy$ lines:
+
+```typescript
+public ngOnDestroy(): void {
+    this.boardsHub.leaveBoard(this.id);
+    this.canvasService.remoteCursors.clear();
+}
+```
+
+#### 2b. Convert constructor injection to inject()
+
+**Current:**
+```typescript
+constructor(
+    private boardsHub: BoardsSignalRService,
+    public canvasService: BoardCanvasService,
+    private activatedRoute: ActivatedRoute,
+    private boardsService: BoardsService,
+    private dialog: MatDialog,
+    private userService: UserService
+) {
+    this.canvasService.boardState = {
+      name: '',
+      autonomousEnabled: false,
+      connections: [],
+      notes: [],
+      boundedContexts: []
+    };
+    this.id = this.activatedRoute.snapshot.paramMap.get('id') || '';
+    this.userName = this.userService.displayName || 'Anonymous';
+    this.previousName = this.canvasService.boardState.name;
+}
+```
+
+**Target:**
+```typescript
+private boardsHub = inject(BoardsSignalRService);
+public canvasService = inject(BoardCanvasService);
+private activatedRoute = inject(ActivatedRoute);
+private boardsService = inject(BoardsService);
+private dialog = inject(MatDialog);
+private userService = inject(UserService);
+private destroyRef = inject(DestroyRef);
+
+constructor() {
+    this.canvasService.boardState = {
+      name: '',
+      autonomousEnabled: false,
+      connections: [],
+      notes: [],
+      boundedContexts: []
+    };
+    this.id = this.activatedRoute.snapshot.paramMap.get('id') || '';
+    this.userName = this.userService.displayName || 'Anonymous';
+    this.previousName = this.canvasService.boardState.name;
+}
+```
+
+Keep constructor for the initialization logic that references injected services.
+
+#### 2c. Replace destroy$ + takeUntil with takeUntilDestroyed
+
+In `subscribeToEvents()`, replace all 16+ instances of `.pipe(takeUntil(this.destroy$))` with `.pipe(takeUntilDestroyed(this.destroyRef))`.
+
+Also in `startPruningCursors()`:
+**Current:**
+```typescript
+private startPruningCursors(): void {
+    const intervalId = setInterval(() => this.pruneStaleRemoteCursors(), 2000);
+    this.destroy$.subscribe(() => clearInterval(intervalId));
+}
+```
+
+**Target:**
+```typescript
+private startPruningCursors(): void {
+    const intervalId = setInterval(() => this.pruneStaleRemoteCursors(), 2000);
+    this.destroyRef.onDestroy(() => clearInterval(intervalId));
+}
+```
+
+This uses `DestroyRef.onDestroy()` callback instead of subscribing to the destroy$ subject.
+
+Remove `private destroy$ = new Subject<void>();` field.
+
+Remove the `destroy$` lines from `ngOnDestroy()`:
+```typescript
+public ngOnDestroy(): void {
+    this.boardsHub.leaveBoard(this.id);
+    this.canvasService.remoteCursors.clear();
+}
+```
+
+Also remove `Subject`, `takeUntil` from the `rxjs` import statement.
+
+#### 2d. Handle ngOnInit board data subscription
+
+The `ngOnInit` has an unguarded `.subscribe()` that doesn't use `takeUntil`:
+```typescript
+this.boardsService.getById(this.id)
+    .subscribe(board => { ... });
+```
+
+This is an HTTP one-shot that completes after emitting — it doesn't need unsubscription. Leave it as-is.
+
+#### 2e. Handle dialog afterClosed subscriptions
+
+Several methods subscribe to `dialogRef.afterClosed()`:
+```typescript
+dialogRef.afterClosed().subscribe((result) => { ... });
+```
+
+These are also one-shot observables (complete after dialog closes). They don't need `takeUntilDestroyed`. Leave as-is.
+
+## Verification Criteria
+
+- [ ] `cd src/eventstormingboard.client && npm run build` passes with no errors
+- [ ] No `@ViewChild` decorators in BoardCanvasComponent
+- [ ] No `destroy$` Subject in either component
+- [ ] No `takeUntil(this.destroy$)` in either component
+- [ ] All 16+ subscription pipes in BoardComponent use `takeUntilDestroyed(this.destroyRef)`
+- [ ] All 3 subscription pipes in BoardCanvasComponent use `takeUntilDestroyed(this.destroyRef)`
+- [ ] `this.canvas().nativeElement` and `this.minimap().nativeElement` used throughout BoardCanvasComponent
+- [ ] Canvas renders correctly (manual visual check recommended)
+- [ ] `DestroyRef.onDestroy()` used for interval cleanup in BoardComponent
+- [ ] `inject()` used for all DI in both components

--- a/.agent-context/tasks/angular-signals-modernization/plan.md
+++ b/.agent-context/tasks/angular-signals-modernization/plan.md
@@ -1,0 +1,57 @@
+# Plan: Angular Signals Modernization
+
+**Objective**: Migrate the entire Angular 21 frontend from legacy patterns (decorator-based inputs/outputs, constructor injection, `destroy$` subjects) to modern Angular signal APIs (`input()`, `output()`, `viewChild()`, `inject()`, `takeUntilDestroyed()`, `effect()`).
+
+**Phases**: 5
+**Estimated complexity**: Medium
+
+## Context
+
+The Angular frontend (37 files, ~6,000 lines) uses zero modern signal patterns despite Angular 21 being fully signal-ready. The `.github/instructions/angular.instructions.md` already mandates full signal adoption. This task performs a systematic, mechanical migration of all legacy patterns to their signal equivalents.
+
+The codebase has 13 components, 7 services, 14 models, and supporting files. The migration is ordered from foundational (services) to complex (large components), ensuring each phase builds cleanly.
+
+### Scope
+
+**In scope** (mechanical transformations):
+- Constructor injection → `inject()` function (all 20+ files)
+- `@Input()` / `@Output()` decorators → `input()` / `output()` signal functions (2 components)
+- `@ViewChild` / `@ViewChildren` → `viewChild()` / `viewChildren()` (3 components)
+- `@Inject(TOKEN)` → `inject(TOKEN)` (6 modal components)
+- `destroy$` Subject + `takeUntil()` → `DestroyRef` + `takeUntilDestroyed()` (5 components)
+- `EventEmitter` → `output()` (1 component)
+- `OnChanges` + `SimpleChanges` → `effect()` (where inputs become signals)
+- Simple `observable$.subscribe(v => this.prop = v)` — considered for `toSignal()` but not feasible (properties used with `[(ngModel)]` require mutability)
+
+**Out of scope** (would require extensive template and logic changes):
+- Converting all plain component properties to `signal()` — too invasive for a mechanical migration
+- Restructuring RxJS Subject-based services to signal-based state — services correctly use Subjects for event streams
+- Converting `board.commands.ts` constructors — these are plain classes, not Angular DI
+- Adding `computed()` for derived state — requires design decisions beyond mechanical transformation
+
+## Phase Summary
+
+| Phase | Name | Description | Files Modified | Verification |
+|-------|------|-------------|----------------|--------------|
+| 1 | Services — inject() | Convert 6 services from constructor injection to inject() (ThemeService has no DI — no changes) | 6 service files | `npm run build` |
+| 2 | Simple Components — inject() | Convert 7 modal components from constructor + @Inject to inject() | 7 component files | `npm run build` |
+| 3 | Root & Splash — inject() + takeUntilDestroyed() | Convert AppComponent and SplashComponent: inject(), destroy$ → takeUntilDestroyed() | 2 component files | `npm run build` |
+| 4 | Signal I/O Components — input/output/viewChild/effect | Convert AiChatPanelComponent and AgentInteractionDiagramComponent: full signal I/O migration + inject() + takeUntilDestroyed() | 2 component files + 1 template file | `npm run build` |
+| 5 | Large Components — inject() + viewChild() + takeUntilDestroyed() | Convert BoardCanvasComponent and BoardComponent: inject(), viewChild(), takeUntilDestroyed() | 2 component files | `npm run build` |
+
+## Dependencies
+
+- Angular 21.2.2 already supports all signal APIs — no package changes needed
+- `@angular/core/rxjs-interop` provides `takeUntilDestroyed()` and `toSignal()` — already available in Angular 21
+- No backend changes required
+- No model file changes required
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `viewChild()` has no `{ static: true }` equivalent — BoardCanvasComponent uses `@ViewChild('canvas', { static: true })` for canvas elements accessed in `ngAfterViewInit` | Signal `viewChild.required()` behaves like `{ static: false }` — it resolves after the view initializes, which is fine for `ngAfterViewInit` access. The existing code only accesses canvas in `ngAfterViewInit → generateCanvas()`, so `viewChild.required()` is safe. Verify canvas init still works. |
+| `OnChanges` removal — AiChatPanelComponent and AgentInteractionDiagramComponent use `OnChanges` + `SimpleChanges` | Replace with `effect()` that watches the signal inputs. The effect runs whenever the input signal changes. |
+| Large file changes — BoardCanvasComponent (1,976 lines) and BoardComponent (995 lines) | Apply minimal changes (inject + takeUntilDestroyed only). No logic restructuring. Do not attempt toSignal or signal() for local state in these files. |
+| `public dialogRef` / `public data` accessed in templates | `inject()` produces instance properties that work identically in templates. No template changes needed for dialog components. |
+| `inject()` must be called in constructor or field initializer context | All `inject()` calls go in field initializers. Any constructor logic that used injected services moves to field initializer or `ngOnInit`. |

--- a/.agent-context/tasks/angular-signals-modernization/progress.md
+++ b/.agent-context/tasks/angular-signals-modernization/progress.md
@@ -9,7 +9,7 @@
 
 | Phase | Name | Started | Completed | Notes |
 |-------|------|---------|-----------|-------|
-| 1 | Services — inject() | | | |
+| 1 | Services — inject() | 2026-04-11T18:01:44Z | | |
 | 2 | Simple Components — inject() | | | |
 | 3 | Root & Splash — inject() + takeUntilDestroyed() | | | |
 | 4 | Signal I/O Components — input/output/viewChild/effect | | | |
@@ -22,7 +22,7 @@
 | Planning | 2026-04-11T17:33:54Z | 2026-04-11T17:43:42Z | Completed | 5 phases |
 | Plan Review | 2026-04-11T17:43:42Z | 2026-04-11T18:00:31Z | Completed | 1 round, 9 findings fixed |
 | Plan Approval | | | Skipped (--auto) | Auto mode |
-| Implementation | | | | |
+| Implementation | 2026-04-11T18:01:44Z | | In Progress | |
 | Implementation Review | | | | |
 | Regression Testing | | | | |
 | Regression Fixes | | | | |

--- a/.agent-context/tasks/angular-signals-modernization/progress.md
+++ b/.agent-context/tasks/angular-signals-modernization/progress.md
@@ -11,8 +11,8 @@
 |-------|------|---------|-----------|-------|
 | 1 | Services — inject() | 2026-04-11T18:01:44Z | 2026-04-11T18:03:56Z | 6 services migrated |
 | 2 | Simple Components — inject() | 2026-04-11T18:03:56Z | 2026-04-11T18:06:25Z | 7 components migrated |
-| 3 | Root & Splash — inject() + takeUntilDestroyed() | 2026-04-11T18:06:25Z | | |
-| 4 | Signal I/O Components — input/output/viewChild/effect | | | |
+| 3 | Root & Splash — inject() + takeUntilDestroyed() | 2026-04-11T18:06:25Z | 2026-04-11T18:08:28Z | 2 components migrated |
+| 4 | Signal I/O Components — input/output/viewChild/effect | 2026-04-11T18:08:28Z | | |
 | 5 | Large Components — inject() + viewChild() + takeUntilDestroyed() | | | |
 
 ## Pipeline Stages

--- a/.agent-context/tasks/angular-signals-modernization/progress.md
+++ b/.agent-context/tasks/angular-signals-modernization/progress.md
@@ -10,8 +10,8 @@
 | Phase | Name | Started | Completed | Notes |
 |-------|------|---------|-----------|-------|
 | 1 | Services — inject() | 2026-04-11T18:01:44Z | 2026-04-11T18:03:56Z | 6 services migrated |
-| 2 | Simple Components — inject() | 2026-04-11T18:03:56Z | | |
-| 3 | Root & Splash — inject() + takeUntilDestroyed() | | | |
+| 2 | Simple Components — inject() | 2026-04-11T18:03:56Z | 2026-04-11T18:06:25Z | 7 components migrated |
+| 3 | Root & Splash — inject() + takeUntilDestroyed() | 2026-04-11T18:06:25Z | | |
 | 4 | Signal I/O Components — input/output/viewChild/effect | | | |
 | 5 | Large Components — inject() + viewChild() + takeUntilDestroyed() | | | |
 

--- a/.agent-context/tasks/angular-signals-modernization/progress.md
+++ b/.agent-context/tasks/angular-signals-modernization/progress.md
@@ -9,8 +9,8 @@
 
 | Phase | Name | Started | Completed | Notes |
 |-------|------|---------|-----------|-------|
-| 1 | Services — inject() | 2026-04-11T18:01:44Z | | |
-| 2 | Simple Components — inject() | | | |
+| 1 | Services — inject() | 2026-04-11T18:01:44Z | 2026-04-11T18:03:56Z | 6 services migrated |
+| 2 | Simple Components — inject() | 2026-04-11T18:03:56Z | | |
 | 3 | Root & Splash — inject() + takeUntilDestroyed() | | | |
 | 4 | Signal I/O Components — input/output/viewChild/effect | | | |
 | 5 | Large Components — inject() + viewChild() + takeUntilDestroyed() | | | |

--- a/.agent-context/tasks/angular-signals-modernization/progress.md
+++ b/.agent-context/tasks/angular-signals-modernization/progress.md
@@ -1,0 +1,66 @@
+# Progress: Angular Signals Modernization
+
+**Task**: Modernize the Angular app to use signals where possible
+**Started**: 2026-04-11T17:33:54Z
+**Status**: In Progress
+**Plan**: [plan.md](plan.md)
+
+## Phase Status
+
+| Phase | Name | Started | Completed | Notes |
+|-------|------|---------|-----------|-------|
+| 1 | Services — inject() | | | |
+| 2 | Simple Components — inject() | | | |
+| 3 | Root & Splash — inject() + takeUntilDestroyed() | | | |
+| 4 | Signal I/O Components — input/output/viewChild/effect | | | |
+| 5 | Large Components — inject() + viewChild() + takeUntilDestroyed() | | | |
+
+## Pipeline Stages
+
+| Stage | Started | Completed | Status | Notes |
+|-------|---------|-----------|--------|-------|
+| Planning | 2026-04-11T17:33:54Z | 2026-04-11T17:43:42Z | Completed | 5 phases |
+| Plan Review | 2026-04-11T17:43:42Z | 2026-04-11T18:00:31Z | Completed | 1 round, 9 findings fixed |
+| Plan Approval | | | Skipped (--auto) | Auto mode |
+| Implementation | | | | |
+| Implementation Review | | | | |
+| Regression Testing | | | | |
+| Regression Fixes | | | | |
+| Regression Re-verify | | | | |
+| Knowledge Update | | | | |
+
+## Issues Log
+
+| Timestamp | Phase | Severity | Description | Resolution |
+|-----------|-------|----------|-------------|------------|
+
+## Knowledge Updates
+
+| File | Action | Summary |
+|------|--------|---------|
+
+## GitHub Tracking
+
+| Key | Value |
+|-----|-------|
+| Tracking Issue | #24 |
+| Issue Node ID | 4245349524 |
+| Branch | task/angular-signals-modernization |
+| PR | — |
+
+### Phase Sub-Issues
+
+| Phase | Name | Issue # | Node ID |
+|-------|------|---------|---------|---|
+| 1 | Services — inject() | #29 | 4245375338 |
+| 2 | Simple Components — inject() | #27 | 4245375336 |
+| 3 | Root & Splash — inject() + takeUntilDestroyed() | #25 | 4245375331 |
+| 4 | Signal I/O Components | #26 | 4245375335 |
+| 5 | Large Components | #28 | 4245375337 |
+
+### Regression Sub-Issue
+
+| Key | Value |
+|-----|-------|
+| Issue # | — |
+| Node ID | — |

--- a/.agent-context/tasks/angular-signals-modernization/progress.md
+++ b/.agent-context/tasks/angular-signals-modernization/progress.md
@@ -12,8 +12,8 @@
 | 1 | Services — inject() | 2026-04-11T18:01:44Z | 2026-04-11T18:03:56Z | 6 services migrated |
 | 2 | Simple Components — inject() | 2026-04-11T18:03:56Z | 2026-04-11T18:06:25Z | 7 components migrated |
 | 3 | Root & Splash — inject() + takeUntilDestroyed() | 2026-04-11T18:06:25Z | 2026-04-11T18:08:28Z | 2 components migrated |
-| 4 | Signal I/O Components — input/output/viewChild/effect | 2026-04-11T18:08:28Z | | |
-| 5 | Large Components — inject() + viewChild() + takeUntilDestroyed() | | | |
+| 4 | Signal I/O Components — input/output/viewChild/effect | 2026-04-11T18:08:28Z | 2026-04-11T18:11:42Z | 2 components migrated |
+| 5 | Large Components — inject() + viewChild() + takeUntilDestroyed() | 2026-04-11T18:11:42Z | | |
 
 ## Pipeline Stages
 

--- a/.agent-context/tasks/angular-signals-modernization/progress.md
+++ b/.agent-context/tasks/angular-signals-modernization/progress.md
@@ -13,7 +13,7 @@
 | 2 | Simple Components — inject() | 2026-04-11T18:03:56Z | 2026-04-11T18:06:25Z | 7 components migrated |
 | 3 | Root & Splash — inject() + takeUntilDestroyed() | 2026-04-11T18:06:25Z | 2026-04-11T18:08:28Z | 2 components migrated |
 | 4 | Signal I/O Components — input/output/viewChild/effect | 2026-04-11T18:08:28Z | 2026-04-11T18:11:42Z | 2 components migrated |
-| 5 | Large Components — inject() + viewChild() + takeUntilDestroyed() | 2026-04-11T18:11:42Z | | |
+| 5 | Large Components — inject() + viewChild() + takeUntilDestroyed() | 2026-04-11T18:11:42Z | 2026-04-11T18:15:47Z | 2 components migrated |
 
 ## Pipeline Stages
 
@@ -22,8 +22,8 @@
 | Planning | 2026-04-11T17:33:54Z | 2026-04-11T17:43:42Z | Completed | 5 phases |
 | Plan Review | 2026-04-11T17:43:42Z | 2026-04-11T18:00:31Z | Completed | 1 round, 9 findings fixed |
 | Plan Approval | | | Skipped (--auto) | Auto mode |
-| Implementation | 2026-04-11T18:01:44Z | | In Progress | |
-| Implementation Review | | | | |
+| Implementation | 2026-04-11T18:01:44Z | 2026-04-11T18:15:47Z | Completed | All 5 phases done |
+| Implementation Review | 2026-04-11T18:15:47Z | 2026-04-11T18:35:13Z | Passed | 1 major + 2 minor fixed |
 | Regression Testing | | | | |
 | Regression Fixes | | | | |
 | Regression Re-verify | | | | |

--- a/.agent-context/tasks/angular-signals-modernization/progress.md
+++ b/.agent-context/tasks/angular-signals-modernization/progress.md
@@ -2,7 +2,7 @@
 
 **Task**: Modernize the Angular app to use signals where possible
 **Started**: 2026-04-11T17:33:54Z
-**Status**: In Progress
+**Status**: Completed
 **Plan**: [plan.md](plan.md)
 
 ## Phase Status

--- a/.agent-context/tasks/angular-signals-modernization/progress.md
+++ b/.agent-context/tasks/angular-signals-modernization/progress.md
@@ -24,10 +24,10 @@
 | Plan Approval | | | Skipped (--auto) | Auto mode |
 | Implementation | 2026-04-11T18:01:44Z | 2026-04-11T18:15:47Z | Completed | All 5 phases done |
 | Implementation Review | 2026-04-11T18:15:47Z | 2026-04-11T18:35:13Z | Passed | 1 major + 2 minor fixed |
-| Regression Testing | | | | |
-| Regression Fixes | | | | |
-| Regression Re-verify | | | | |
-| Knowledge Update | | | | |
+| Regression Testing | 2026-04-11T18:35:13Z | 2026-04-11T18:43:44Z | Passed | 8 pass, 2 manual only |
+| Regression Fixes | | | Not Needed | |
+| Regression Re-verify | | | Skipped | |
+| Knowledge Update | 2026-04-11T18:43:44Z | 2026-04-11T18:46:02Z | Completed | architecture-principles.md updated |
 
 ## Issues Log
 
@@ -38,6 +38,7 @@
 
 | File | Action | Summary |
 |------|--------|---------|
+| .agent-context/knowledge/architecture-principles.md | Updated | Signal adoption expanded to cover viewChild(), effect(), takeUntilDestroyed() |
 
 ## GitHub Tracking
 
@@ -46,7 +47,7 @@
 | Tracking Issue | #24 |
 | Issue Node ID | 4245349524 |
 | Branch | task/angular-signals-modernization |
-| PR | — |
+| PR | #30 |
 
 ### Phase Sub-Issues
 
@@ -62,5 +63,5 @@
 
 | Key | Value |
 |-----|-------|
-| Issue # | — |
-| Node ID | — |
+| Issue # | #31 |
+| Node ID | 4245491301 |

--- a/.agent-context/tasks/spec-refinement/plan.md
+++ b/.agent-context/tasks/spec-refinement/plan.md
@@ -1,0 +1,199 @@
+# Plan: Spec Refinement Stage with Remote Q&A
+
+Add a Specification stage to the Orchestrator pipeline that always delegates spec authoring to a Spec Writer subagent. The Orchestrator never writes spec.md directly. The Spec Writer receives a `refine` setting: when true, it invokes the Question Relay subagent for remote Q&A via GitHub issue comments and incorporates answers; when false, it drafts the spec without Q&A. The Question Relay remains a standalone reusable agent invocable by any agent that needs user input.
+
+## Design Decisions
+
+- **Trigger**: Opt-in via `--refine-spec` flag (detected alongside `--auto`)
+- **Q&A mechanism**: Post questions as an issue comment via `mcp_github_add_issue_comment`; poll `mcp_github_issue_read` (`get_comments`) for user replies after the question comment
+- **Polling**: Dedicated Question Relay agent stays alive (hot context), polls periodically with a terminal sleep between checks, up to a configurable max wait. Returns answers (or timeout) to the calling agent
+- **Reusable**: Question Relay is a standalone agent invocable by any agent that needs user input (Spec Writer, Planner, etc.)
+- **Spec Writer owns Q&A**: The Spec Writer directly invokes the Question Relay as a subagent when it has questions — the Orchestrator does not coordinate between them
+- **Spec format**: Lightweight industry-standard specification (simplified PRD/SRS) — non-technical
+
+## Steps
+
+### Phase 1: Question Relay Agent
+
+Create a new Question Relay agent at `.github/agents/question-relay.agent.md`. This agent owns the entire Q&A lifecycle: posting questions to a GitHub issue and polling until the user responds.
+
+1. **Create the Question Relay agent** with:
+   - Model: Claude Sonnet 4.6 (fast, low cost — mostly waiting)
+   - Tools: `[read, "github/*"]` (needs GitHub access to post/read comments)
+   - Single mode of operation: receives questions, posts them, polls for answers, returns results
+
+2. **Agent input** (provided by the calling agent in the prompt):
+   - Tracking issue number
+   - Source agent name (e.g., "Spec Writer", "Planner") — for attribution in the comment
+   - List of numbered questions
+   - Poll interval (default: 60 seconds)
+   - Max attempts (default: 30)
+
+3. **Agent behaviour**:
+   - **Step 1**: Post a comment on the tracking issue via `mcp_github_add_issue_comment`:
+     ```
+     ## 🤖 Questions from {source agent}
+
+     @matt-bentley — Please reply to this comment with your answers.
+
+     1. {question 1}
+     2. {question 2}
+     ...
+     ```
+   - **Step 2**: Enter a poll loop:
+     - Run `Start-Sleep -Seconds {interval}` in terminal (PowerShell)
+     - Read issue comments via `mcp_github_issue_read` (method: `get_comments`)
+     - Look for comments posted *after* the questions comment that are not from a bot
+     - If user reply found → exit loop
+     - If no reply → repeat (up to max attempts)
+   - **Step 3**: Return structured output:
+     - On answers found: `## QA: ANSWERS_FOUND\n{raw comment body}`
+     - On timeout: `## QA: TIMEOUT\nNo response after {max attempts} attempts ({total wait} minutes)`
+
+4. **Agent prompt protocol**:
+   - The agent must NOT interpret or process answers — it returns raw comment text
+   - The agent must log each poll attempt (attempt N of M) for observability
+   - On timeout, the agent returns gracefully (no error) so the calling agent can decide how to proceed
+
+### Phase 2: Spec Writer Agent
+
+Create a new Spec Writer agent at `.github/agents/spec-writer.agent.md`.
+
+4. **Create the Spec Writer agent** with:
+   - Model: Claude Opus 4.6
+   - Tools: `[read, search]` (read-only codebase access — no board edits, no direct GitHub access)
+   - Subagent access: Can invoke the Question Relay agent via `runSubagent` for Q&A
+   - Single invocation from the Orchestrator — the Spec Writer always writes the spec:
+     1. Draft the spec from the user request
+     2. If `refine: true` AND clarifying questions exist → invoke Question Relay subagent with the tracking issue # and questions
+     3. If answers received → incorporate answers and refine the spec
+     4. If timeout → leave unanswered questions in `## Open Questions` and return the current spec
+     5. If `refine: false` → skip Q&A entirely (no Question Relay invocation)
+     6. Return the final `spec.md`
+
+5. **Spec.md format** — simplified PRD/requirements doc (non-technical):
+   ```markdown
+   # Specification: {Title}
+
+   ## Overview
+   {1-2 paragraph summary of what is being built and why}
+
+   ## Goals
+   - {Goal 1}
+   - {Goal 2}
+
+   ## User Stories
+   - As a {persona}, I want {action} so that {benefit}
+
+   ## Functional Requirements
+   | ID | Requirement | Priority |
+   |----|------------|----------|
+   | FR-1 | {requirement} | Must / Should / Could |
+
+   ## Non-Functional Requirements
+   - {Performance, security, accessibility constraints}
+
+   ## Constraints & Assumptions
+   - {Known constraints}
+   - {Assumptions made}
+
+   ## Out of Scope
+   - {Explicitly excluded items}
+
+   ## Open Questions
+   - {Any unresolved questions — populated from unanswered GitHub questions}
+   ```
+
+6. **Spec Writer prompt protocol**:
+   - The agent receives: user request, tracking issue number, task slug, `refine` setting (true/false), and relevant repository context
+   - The agent always drafts a structured spec from the user request
+   - If `refine: true`, the agent self-evaluates whether clarifying questions are needed
+   - If `refine: false`, the agent skips Q&A and returns the draft spec immediately
+   - If questions are needed (and `refine: true`), the agent invokes the Question Relay subagent directly:
+     ```
+     runSubagent("Question Relay", prompt: "
+       Tracking issue: #{issue_number}
+       Source agent: Spec Writer
+       Questions:
+       1. {question 1}
+       2. {question 2}
+       Poll interval: 60 seconds
+       Max attempts: 30
+     ")
+     ```
+   - On receiving answers from Question Relay (`## QA: ANSWERS_FOUND`), the agent incorporates them into the spec and removes answered items from Open Questions
+   - On timeout (`## QA: TIMEOUT`), the agent logs a note and leaves unanswered questions in `## Open Questions`
+   - If no questions are needed, the agent skips Q&A entirely
+   - The agent writes the final `spec.md` to `.agent-context/tasks/{task-slug}/spec.md` and returns a summary of what was produced
+
+### Phase 3: Orchestrator Pipeline Changes
+
+Modify the Orchestrator to add the Specification stage between Initialisation and Planning.
+
+7. **Add `--refine-spec` flag detection** alongside existing `--auto` detection in the "Auto Mode Detection" section
+   - Scan user message for `--refine-spec` (case-insensitive)
+   - Remove it from the task description when creating files
+
+8. **Add new Stage 2: Specification** (shifts all subsequent stages by 1):
+   - **Step 1 — Always**: Invoke Spec Writer subagent (single invocation):
+     - Input: raw user request, tracking issue #, task slug, `refine: true/false` (based on `--refine-spec` flag), relevant repository context
+     - The Spec Writer always drafts and writes the structured spec.md
+     - If `refine: true`, the Spec Writer handles Q&A internally via Question Relay → refine → write final spec.md
+     - If `refine: false`, the Spec Writer drafts the spec without Q&A and writes it immediately
+     - The Orchestrator never writes spec.md directly — the Spec Writer owns all spec authoring
+   - **Step 2**: Invoke Delivery Manager `stage_update`: Stage "Specification", Status: Completed
+   - **Step 3**: Update progress file: Specification → Completed (with notes on whether refinement was enabled and whether questions were asked/answered)
+
+9. **Update progress file reference** to include `**Spec**: [spec.md](spec.md)` alongside the existing `**Plan**` link
+
+10. **Pass spec.md to the Planner**: Update the Planner invocation to include the spec file path so the Planner uses the refined spec as its input rather than the raw task description
+
+### Phase 4: Progress & Template Updates
+
+11. **Update progress file template** in [.github/instructions/agent-progress.instructions.md](../../.github/instructions/agent-progress.instructions.md):
+    - Add `Specification` row to Pipeline Stages table (between Planning row — it becomes the first stage after Init)
+    - Add `**Spec**: [spec.md](spec.md)` to file header fields
+
+12. **Update Issue Body Templates** in the Delivery Manager:
+    - Add "Specification" row to both Init and Plan Ready Pipeline tables
+    - Init template shows `Specification | 🔄 In Progress`
+    - No new commands are added to the Delivery Manager — Q&A is handled by the Question Relay agent
+
+13. **Update Orchestrator stage numbering**: Renumber all stages (current Stage 2: Planning becomes Stage 3, etc.)
+
+## Relevant Files
+
+- `.github/agents/orchestrator.agent.md` — Add flag detection, new Specification stage, Spec Writer invocation (single call), renumber stages
+- `.github/agents/question-relay.agent.md` — **New file**: Question Relay agent (posts questions to GitHub, polls for answers)
+- `.github/agents/spec-writer.agent.md` — **New file**: Spec Writer agent definition
+- `.github/agents/delivery-manager.agent.md` — Update issue body templates only (no new commands)
+- `.github/instructions/agent-progress.instructions.md` — Add Specification stage row, spec file reference
+
+## Verification
+
+1. Read through the Orchestrator flow end-to-end and verify stage numbering is consistent (no gaps, no duplicate stage numbers)
+2. Verify Question Relay agent has GitHub tools (`github/*`) and follows the agent file conventions
+3. Verify Spec Writer agent has the correct tool permissions (read-only codebase access + subagent invocation for Question Relay)
+4. Verify the progress file template includes the new Specification stage
+5. Verify the issue body templates include the Specification stage in the Pipeline table
+6. Verify the `--refine-spec` flag is stripped from the task description (same pattern as `--auto`)
+7. Verify the Question Relay's poll loop has a clear timeout and graceful fallback
+8. Trace a full pipeline run mentally: with `--refine-spec` (questions + answers), with `--refine-spec` (questions + timeout), without `--refine-spec` (Spec Writer drafts without Q&A)
+9. Verify the Spec Writer's subagent invocation of Question Relay includes all required parameters (tracking issue #, source agent name, questions, poll config)
+
+## Decisions
+
+- `--refine-spec` is opt-in (not auto-detected)
+- Poll interval: 60 seconds, max 10 attempts (~10 minutes) — passed to the Question Relay agent as parameters
+- Questions posted as issue comments via `mcp_github_add_issue_comment`; answers detected from subsequent issue comments via `get_comments`
+- No `clear_questions` needed — comments are a natural conversation thread
+- Question Relay is a standalone agent (not part of the Delivery Manager) — owns the full post-and-poll lifecycle, reusable by any agent
+- Spec Writer always writes the spec — the Orchestrator never writes spec.md directly. The Orchestrator passes a `refine` setting (from `--refine-spec` flag) and the Spec Writer decides whether to invoke Q&A based on that setting
+- The Planner receives the spec.md path and uses it as primary input
+- Spec format is a simplified PRD — non-technical, industry-standard
+
+## Further Considerations
+
+1. **Planner integration**: When the Planner needs Q&A later, it invokes the Question Relay subagent directly with its own questions and tracking issue #. Same pattern as the Spec Writer — the calling agent owns the lifecycle, not the Orchestrator.
+2. **Poll timeout**: 10 minutes may be too short for complex specs. Consider making this configurable via the flag (e.g., `--refine-spec:20` for 20 min). Recommendation: keep simple for now (fixed 10 min), extend later.
+3. **Multiple Q&A rounds**: Current design supports one round of questions. If the refined spec still has questions, a second round could be added later. Recommendation: one round only for v1.

--- a/.github/agents/delivery-manager.agent.md
+++ b/.github/agents/delivery-manager.agent.md
@@ -169,7 +169,8 @@ Use this template for the tracking issue body on `init` (before planning is comp
 
 | Stage | Status |
 |-------|--------|
-| Planning | 🔄 In Progress |
+| Specification | 🔄 In Progress |
+| Planning | ⏳ Pending |
 | Plan Review | ⏳ Pending |
 | Implementation | ⏳ Pending |
 | Implementation Review | ⏳ Pending |
@@ -202,6 +203,7 @@ Use this template when updating the issue body on `plan_ready`:
 
 | Stage | Status |
 |-------|--------|
+| Specification | ✅ Completed |
 | Planning | ✅ Completed |
 | Plan Review | 🔄 In Progress |
 | Implementation | ⏳ Pending |

--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -17,6 +17,14 @@ Scan the user's message for the literal string `--auto` (case-insensitive). If p
 
 If `--auto` is NOT present, pause after plan review and present the plan to the user for approval before proceeding.
 
+## Refine Spec Detection
+
+Scan the user's message for the literal string `--refine-spec` (case-insensitive). If present:
+- Set `refine-spec: true` — the Spec Writer will invoke Q&A via the Question Relay agent
+- Remove `--refine-spec` from the task description when creating progress/plan files
+
+If `--refine-spec` is NOT present, set `refine-spec: false` — the Spec Writer drafts the spec without Q&A.
+
 ## Pipeline Workflow
 
 ### Stage 1: Initialisation
@@ -30,9 +38,23 @@ If `--auto` is NOT present, pause after plan review and present the plan to the 
 4. **Parse Delivery Manager output**: Look for `## Delivery: INIT`. Extract Issue # and IssueNodeId. Write all values to the progress file `## GitHub Tracking` section.
    - If the Delivery Manager returns `## Delivery: ERROR`, log a warning to the Issues Log and continue. Set a flag `github-tracking-disabled` — skip all subsequent Delivery Manager calls.
 
-### Stage 2: Planning
+### Stage 2: Specification
 
-1. **Invoke the Planner** with the user's task description. The Planner creates:
+1. **Invoke the Spec Writer** subagent (single invocation — the Orchestrator never writes spec.md directly):
+   > User request: {raw task description}. Tracking issue: #{number}. Task slug: {task-slug}. Refine: {true/false} (from `--refine-spec` detection). Repository context: relevant knowledge and instructions.
+   - The Spec Writer always drafts a structured `spec.md`
+   - If `refine: true`, the Spec Writer handles Q&A internally via the Question Relay agent
+   - If `refine: false`, the Spec Writer drafts the spec without Q&A
+2. **Parse Spec Writer output**: Look for `## Spec: COMPLETE`. Verify the spec file was written.
+3. Update progress file: Specification → Completed (with notes on whether refinement was enabled and whether questions were asked/answered).
+4. **Invoke the Delivery Manager** with `stage_update`:
+   > Command: `stage_update`. Tracking issue: #{number}. Stage: Specification. Status: Completed.
+
+### Stage 3: Planning
+
+1. **Invoke the Planner** with the spec file as primary input:
+   > Implement the specification at `.agent-context/tasks/{task-slug}/spec.md`. Raw user request: {task description}.
+   The Planner creates:
    - `.agent-context/tasks/{task-slug}/plan.md` (master plan)
    - `.agent-context/tasks/{task-slug}/phase-{N}-{name}.md` (per-phase details)
 2. Update progress file: Planning → Completed.
@@ -40,7 +62,7 @@ If `--auto` is NOT present, pause after plan review and present the plan to the 
    > Command: `plan_ready`. Tracking issue: #{number}. Issue Node ID: {from GitHub Tracking}. Plan summary: {phase names and descriptions from plan.md}.
 4. **Parse Delivery Manager output**: Look for `## Delivery: PLAN_READY`. Extract all phase sub-issue numbers and node IDs. Write each row to the progress file `## GitHub Tracking` → `### Phase Sub-Issues` table.
 
-### Stage 3: Plan Review
+### Stage 4: Plan Review
 
 1. **Invoke the Refiner** to review and fix the plan:
    > Review the plan files in `.agent-context/tasks/{task-slug}/` with 1 round. The master plan is at `.agent-context/tasks/{task-slug}/plan.md` and phase files are in the same directory.
@@ -48,14 +70,14 @@ If `--auto` is NOT present, pause after plan review and present the plan to the 
 3. **Invoke the Delivery Manager** with `stage_update`:
    > Command: `stage_update`. Tracking issue: #{number}. Stage: Plan Review. Status: Completed.
 
-### Stage 4: Plan Approval
+### Stage 5: Plan Approval
 
 1. **If `--auto` was detected**: Skip approval, update progress file: Plan Approval → Skipped (--auto).
 2. **Otherwise**: Present the plan summary to the user and wait for approval. Update progress file accordingly.
 3. **Invoke the Delivery Manager** with `stage_update`:
    > Command: `stage_update`. Tracking issue: #{number}. Stage: Plan Approval. Status: {Approved / Skipped (--auto)}.
 
-### Stage 5: Per-Phase Implementation
+### Stage 6: Per-Phase Implementation
 
 1. **Commit pre-implementation baseline**: Run `git add -A && git commit -m "pre-implementation baseline"` to create a single baseline for the full implementation diff. Record this commit hash — it is used by the Implementation Reviewer later.
 
@@ -69,7 +91,7 @@ For each phase (1 through N):
 6. **Invoke the Delivery Manager** with `phase_end`:
    > Command: `phase_end`. Phase: {N}. Phase sub-issue issue #: {from GitHub Tracking}. Tracking issue #: {from GitHub Tracking}. Status: completed.
 
-### Stage 6: Implementation Review
+### Stage 7: Implementation Review
 
 1. **Invoke the Delivery Manager** with `stage_update`:
    > Command: `stage_update`. Tracking issue: #{number}. Stage: Implementation Review. Status: In Progress.
@@ -86,11 +108,11 @@ For each phase (1 through N):
      7. Continue to regression testing.
    - **FAIL**: Update progress file: Implementation Review → Failed. Log error to Issues Log. Update task status to Failed. **Invoke the Delivery Manager** with `complete` (status: failed). **Halt pipeline** with a summary of what failed.
 
-### Stage 7: Regression Testing
+### Stage 8: Regression Testing
 
 1. **Invoke the Delivery Manager** with `regression_update`:
    > Command: `regression_update`. Regression sub-issue issue #: {from GitHub Tracking}. Status: in_progress.
-2. **Start the application**: Launch the app using the VS Code task `StormSpace` (this starts the backend with SPA proxy, which also serves the Angular frontend). After starting the task, wait for the app to become accessible at `https://localhost:51710` by polling the URL. If the app does not become accessible within a reasonable time, **halt** and report the startup failure.
+2. **Start the application**: Launch the app using the VS Code task `StormSpace` (this starts the backend with SPA proxy, which also serves the Angular frontend). After starting the task, wait for the app to become accessible at `https://localhost:51710` by polling the URL. If the app does not become accessible within a reasonable time, **stop the app** (kill the `StormSpace` terminal), **halt** and report the startup failure.
 3. **Invoke the Regression Tester** with the list of changed files across all phases:
    > Run regression testing. Changed files: {list of all files changed across phases}. App URL: https://localhost:51710
 4. **Parse Regression Tester output**: Look for `## Regression Status: PASS` or `## Regression Status: FAIL`.
@@ -99,10 +121,11 @@ For each phase (1 through N):
      2. **Invoke the Delivery Manager** with `regression_update`:
         > Command: `regression_update`. Regression sub-issue issue #: {from GitHub Tracking}. Status: passed.
      3. **Invoke the Delivery Manager** with `stage_update`: Stage: Regression Testing. Status: Passed.
-     4. Proceed to Knowledge Update.
+     4. **Stop the application**: Kill the `StormSpace` terminal to free the port.
+     5. Proceed to Knowledge Update.
    - **FAIL**: Update progress file: Regression Testing → Failed. Proceed to regression fix cycle.
 
-### Stage 8: Regression Fix Cycle (if needed)
+### Stage 9: Regression Fix Cycle (if needed)
 
 1. **Invoke the Implementer** to fix regression issues:
    > Fix the following regression issues found by the Regression Tester: {failure details from Regression Tester output}
@@ -115,11 +138,12 @@ For each phase (1 through N):
      3. **Invoke the Delivery Manager** with `regression_update`:
         > Command: `regression_update`. Regression sub-issue issue #: {from GitHub Tracking}. Status: passed.
      4. **Invoke the Delivery Manager** with `stage_update`: Stage: Regression Re-verify. Status: Passed.
-   - **FAIL**: Update progress file with remaining issues. **Invoke the Delivery Manager** with `complete` (status: failed). **Halt pipeline** — do not loop further. Report remaining regressions to user.
+     5. **Stop the application**: Kill the `StormSpace` terminal to free the port.
+   - **FAIL**: **Stop the application**: Kill the `StormSpace` terminal. Update progress file with remaining issues. **Invoke the Delivery Manager** with `complete` (status: failed). **Halt pipeline** — do not loop further. Report remaining regressions to user.
 
 **Cap**: At most 1 fix cycle. If regressions persist after one Implementer fix attempt, halt and report.
 
-### Stage 9: Knowledge Update
+### Stage 10: Knowledge Update
 
 1. **Invoke the Knowledge Keeper**:
    > Update knowledge documentation to reflect the changes made during this task. Changed files: {list}. Task: {description}.
@@ -128,7 +152,7 @@ For each phase (1 through N):
 4. **Invoke the Delivery Manager** with `stage_update`:
    > Command: `stage_update`. Tracking issue: #{number}. Stage: Knowledge Update. Status: Completed.
 
-### Stage 10: Completion
+### Stage 11: Completion
 
 1. Update progress file: Status → Completed.
 2. **Invoke the Delivery Manager** with the `complete` command:

--- a/.github/agents/question-relay.agent.md
+++ b/.github/agents/question-relay.agent.md
@@ -1,0 +1,80 @@
+---
+name: "Question Relay"
+description: "Posts questions to a GitHub issue and polls for user replies. Use when: any agent needs interactive Q&A with the user via GitHub issue comments. Reusable by Spec Writer, Planner, or any agent."
+tools: [read, "github/*"]
+model: "Claude Sonnet 4.6"
+user-invocable: false
+---
+
+# Question Relay — GitHub Issue Q&A Agent
+
+You are the Question Relay. You post questions on a GitHub issue and poll for a user reply. You are a reusable utility agent — any agent that needs interactive user input can invoke you.
+
+## Input
+
+The calling agent provides these parameters in the prompt:
+
+- **Tracking issue number** — the GitHub issue to post questions on
+- **Source agent name** — the agent requesting answers (e.g., "Spec Writer", "Planner") — used for attribution
+- **Questions** — numbered list of questions to ask
+- **Poll interval** (default: 60 seconds) — time between poll attempts
+- **Max attempts** (default: 10) — maximum number of poll cycles before timeout
+
+## Configuration
+
+Read the repository and owner from `.github/copilot-instructions.md` under `## GitHub Project`.
+
+## Workflow
+
+### Step 1: Post Questions
+
+Post a comment on the tracking issue via `mcp_github_add_issue_comment`:
+
+```markdown
+## 🤖 Questions from {source agent}
+
+@matt-bentley — Please reply to this comment with your answers.
+
+1. {question 1}
+2. {question 2}
+...
+```
+
+Record the timestamp or comment ID of the posted comment for reference.
+
+### Step 2: Poll for Answers
+
+Enter a poll loop:
+
+1. Wait for the poll interval by running `Start-Sleep -Seconds {interval}` in the terminal
+2. Read issue comments via `mcp_github_issue_read` (method: `get_comments`)
+3. Look for comments posted **after** the questions comment that:
+   - Are NOT from a bot account
+   - Contain substantive content (not just reactions or empty text)
+4. If a qualifying reply is found → exit the loop
+5. If no reply → log `Poll attempt {N} of {max}: no reply yet` and repeat
+6. If max attempts reached → exit the loop with timeout
+
+### Step 3: Return Results
+
+Return structured output based on the outcome:
+
+**On answers found:**
+```
+## QA: ANSWERS_FOUND
+{raw comment body from the user's reply}
+```
+
+**On timeout:**
+```
+## QA: TIMEOUT
+No response after {max attempts} attempts ({total wait} minutes).
+```
+
+## Rules
+
+- **Do NOT interpret or process answers** — return the raw comment text exactly as posted
+- **Log each poll attempt** for observability (attempt N of M)
+- **On timeout, return gracefully** — do not error or halt. The calling agent decides how to handle timeout
+- **Do not modify the issue** beyond posting the initial questions comment
+- **Do not post follow-up comments** — one questions comment only

--- a/.github/agents/regression-tester.agent.md
+++ b/.github/agents/regression-tester.agent.md
@@ -1,14 +1,16 @@
 ---
 name: "Regression Tester"
-description: "Browser-based user journey regression testing. Walks through all 10 user journeys via browser automation, prioritising journeys affected by changed files. Reports issues but does NOT fix them."
-tools: [read, search, execute, browser]
+description: "Browser-based user journey regression testing. Walks through all user journeys via browser automation, prioritising journeys affected by changed files. Reports issues but does NOT fix them."
+tools: [read, search, execute]
 model: "Claude Sonnet 4.6"
-user-invocable: false
+user-invocable: true
 ---
 
 # Regression Tester — Browser-Based User Journey Testing
 
 You are the Regression Tester. You walk through the application's user journeys via browser automation to detect regressions introduced by recent changes. You report issues but never fix them.
+
+You use the `playwright-cli` skill for all browser automation. Read `.github/skills/playwright-cli/SKILL.md` before starting any journeys.
 
 ## Input
 
@@ -19,8 +21,14 @@ The Orchestrator provides:
 ## Preconditions
 
 Before starting any journeys, verify the app is accessible:
-1. Navigate to `https://localhost:51710`
-2. Confirm the page loads (look for the splash page content)
+1. Open a browser and navigate to the app:
+   ```bash
+   playwright-cli open https://localhost:51710
+   ```
+2. Take a snapshot and confirm the splash page loads:
+   ```bash
+   playwright-cli snapshot
+   ```
 3. If the app is not accessible, report immediately:
    ```
    ## Regression Status: FAIL (0 automated failures)
@@ -32,7 +40,7 @@ Before starting any journeys, verify the app is accessible:
 
 ### Step 1: Load Journey Definitions
 
-Read `.agent-context/knowledge/user-journeys.md` to get all 10 user journey definitions with their browser selectors and verification steps.
+Read `.agent-context/knowledge/user-journeys.md` to get all user journey definitions with their playwright-cli commands and verification steps.
 
 ### Step 2: Prioritise Journeys
 
@@ -42,24 +50,32 @@ Map the changed files to affected journeys:
 
 ### Step 3: Execute Journeys
 
-Walk through each journey using browser automation:
+Walk through each journey using `playwright-cli`:
 1. Follow the steps defined in `user-journeys.md`
-2. Use the CSS selectors and interaction patterns specified
-3. Verify each step's expected outcome
-4. Record pass/fail for each journey
+2. Use `playwright-cli snapshot` to read page structure and identify element refs
+3. Use `playwright-cli click`, `playwright-cli fill`, `playwright-cli press` etc. to interact
+4. Use `playwright-cli eval` for canvas coordinate-based operations
+5. Verify each step's expected outcome via snapshots
+6. Use `playwright-cli screenshot` to capture visual state when failures are detected
+7. Record pass/fail for each journey
 
-**Canvas interactions**: StormSpace uses HTML Canvas for the board. Canvas-based interactions (sticky note creation, drag-and-drop, connection drawing) cannot be fully automated via browser tools. For journeys involving Canvas:
-- Test the non-Canvas parts (navigation, dialogs, toolbars, chat)
-- Mark Canvas-specific interactions as "manual verification needed"
-- "Manual verification needed" does NOT count as a regression failure
+### Step 4: Cleanup
 
-### Step 4: Report
+Delete any screenshot, snapshot, and console log files generated during testing from the `.playwright-cli` directory:
+
+```bash
+Get-ChildItem -Path ".playwright-cli" | Where-Object { ($_.Name -like "journey*.png") -or ($_.Name -like "page-*.yml") -or ($_.Name -like "console-*.log") } | Remove-Item -Force
+```
+
+Note: playwright-cli stores all artefacts in `.playwright-cli\` (not the workspace root).
+
+### Step 5: Report
 
 Output your result using this **mandatory format**:
 
 **If all automated checks pass:**
 ```
-## Regression Status: PASS ({N} journeys passed, {M} manual verification needed)
+## Regression Status: PASS ({N} journeys passed)
 
 ### Journey Results
 
@@ -67,12 +83,11 @@ Output your result using this **mandatory format**:
 |---|---------|--------|-------|
 | 1 | Create a Board | ✓ Pass | |
 | 2 | Join an Existing Board | ✓ Pass | |
-| 3 | Create Sticky Notes | ⚠ Manual | Canvas interactions require manual verification |
 ...
 
 ### Manual Verification Needed
 
-{List of specific Canvas or complex interactions that need manual testing}
+{List of specific complex interactions that need manual testing}
 ```
 
 **If automated failures are detected:**
@@ -96,14 +111,13 @@ Output your result using this **mandatory format**:
 
 ### Manual Verification Needed
 
-{List of Canvas interactions that need manual testing}
+{List of specific complex interactions that need manual testing}
 ```
 
 ## Rules
 
 - **Report only, never fix.** Your job is to find issues, not resolve them.
 - **Mandatory output format.** The Orchestrator parses `## Regression Status: PASS|FAIL` to gate pipeline flow. Always include this heading.
-- **Canvas interactions are not regressions.** Mark them as "manual verification needed" — they do not count as automated failures.
-- **Test all 10 journeys.** Even if affected journeys pass, run the rest to catch unexpected side effects.
+- **Test all user journeys.** Even if affected journeys pass, run the rest to catch unexpected side effects.
 - **Be specific in failure reports.** Include the exact step, expected vs actual behavior, and any error messages.
 - **Prioritise affected journeys.** Run journeys mapped to changed files first.

--- a/.github/agents/spec-writer.agent.md
+++ b/.github/agents/spec-writer.agent.md
@@ -1,0 +1,116 @@
+---
+name: "Spec Writer"
+description: "Drafts structured specifications from user requests. Optionally refines via Q&A using the Question Relay agent. Use when: creating spec.md for a task before planning."
+tools: [read, search, edit]
+model: "Claude Opus 4.6"
+user-invocable: false
+---
+
+# Spec Writer — Specification Author
+
+You are the Spec Writer. You produce a structured `spec.md` from a user's task request. When refinement is enabled, you invoke the Question Relay agent to gather clarifying answers from the user via GitHub issue comments.
+
+## Input
+
+The Orchestrator provides:
+
+- **User request** — the raw task description
+- **Tracking issue number** — the GitHub tracking issue for this task
+- **Task slug** — used for file paths
+- **Refine** — `true` or `false` (whether to invoke Q&A via Question Relay)
+- **Repository context** — relevant knowledge, instructions, or codebase context
+
+## Workflow
+
+### Step 1: Draft the Specification
+
+Analyse the user request and any provided repository context. Draft a structured specification following the format below. Use your understanding of the codebase and domain to fill in as much detail as possible.
+
+### Step 2: Evaluate Need for Clarification (refine mode only)
+
+If `refine: true`:
+
+1. Review the draft spec for ambiguities, missing requirements, or unclear scope
+2. Formulate concise, numbered clarifying questions (if any are needed)
+3. If questions exist → proceed to Step 3
+4. If no questions needed → skip to Step 4
+
+If `refine: false`: skip directly to Step 4.
+
+### Step 3: Invoke Question Relay (refine mode only)
+
+Invoke the Question Relay subagent:
+
+```
+runSubagent("Question Relay", prompt: "
+  Tracking issue: #{tracking_issue_number}
+  Source agent: Spec Writer
+  Questions:
+  1. {question 1}
+  2. {question 2}
+  ...
+  Poll interval: 60 seconds
+  Max attempts: 10
+")
+```
+
+Parse the Question Relay response:
+
+- **`## QA: ANSWERS_FOUND`**: Incorporate the user's answers into the spec. Remove answered items from Open Questions. Refine requirements based on the answers.
+- **`## QA: TIMEOUT`**: Log a note that Q&A timed out. Leave unanswered questions in the `## Open Questions` section of the spec.
+
+### Step 4: Write the Final Spec
+
+Write the final specification to `.agent-context/tasks/{task-slug}/spec.md`.
+
+Return a summary of what was produced:
+```
+## Spec: COMPLETE
+Path: .agent-context/tasks/{task-slug}/spec.md
+Refined: {yes/no}
+Questions asked: {N or 0}
+Questions answered: {N or 0}
+Open questions: {N or 0}
+```
+
+## Spec Format
+
+```markdown
+# Specification: {Title}
+
+## Overview
+{1-2 paragraph summary of what is being built and why}
+
+## Goals
+- {Goal 1}
+- {Goal 2}
+
+## User Stories
+- As a {persona}, I want {action} so that {benefit}
+
+## Functional Requirements
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | {requirement} | Must / Should / Could |
+
+## Non-Functional Requirements
+- {Performance, security, accessibility constraints}
+
+## Constraints & Assumptions
+- {Known constraints}
+- {Assumptions made}
+
+## Out of Scope
+- {Explicitly excluded items}
+
+## Open Questions
+- {Any unresolved questions — populated from unanswered GitHub questions or ambiguities}
+```
+
+## Rules
+
+- **Always produce a spec** — even without Q&A, draft the best spec possible from available information
+- **Do not modify the codebase** — you have read-only access. Your output is `spec.md` only
+- **Keep the spec non-technical** — write requirements in business/user terms, not implementation details. The Planner translates to technical implementation
+- **Be concise** — each section should be scannable. Use tables and bullet points over prose
+- **Preserve the format** — the Planner expects the spec format above. Do not deviate from the section structure

--- a/.github/instructions/agent-progress.instructions.md
+++ b/.github/instructions/agent-progress.instructions.md
@@ -18,6 +18,7 @@ Progress files track the status of agentic workflow pipeline runs. They are crea
 **Task**: {Brief description of what was requested}
 **Started**: {utc-datetime}
 **Status**: {In Progress | Completed | Failed | Halted}
+**Spec**: [spec.md](spec.md)
 **Plan**: [plan.md](plan.md)
 
 ## Phase Status
@@ -31,6 +32,7 @@ Progress files track the status of agentic workflow pipeline runs. They are crea
 
 | Stage | Started | Completed | Status | Notes |
 |-------|---------|-----------|--------|-------|
+| Specification | | | {Completed / Failed} | {notes} |
 | Planning | {utc-datetime} | {utc-datetime} | {Completed / Failed} | {notes} |
 | Plan Review | | | {Completed / Failed} | {notes} |
 | Plan Approval | | | {Approved / Pending / Skipped (--auto)} | {notes} |

--- a/.github/skills/playwright-cli/SKILL.md
+++ b/.github/skills/playwright-cli/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: playwright-cli
+description: Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages.
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+playwright-cli fill e5 "user@example.com"
+playwright-cli drag e2 e8
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli snapshot --filename=after-click.yaml
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli network
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start
+playwright-cli video-stop video.webm
+```
+
+### Install
+
+```bash
+playwright-cli install --skills
+playwright-cli install-browser
+```
+
+### Configuration
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+# Connect to browser via extension
+playwright-cli open --extension
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+### Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli network
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Specific tasks
+
+* **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+* **Running Playwright code** [references/running-code.md](references/running-code.md)
+* **Browser session management** [references/session-management.md](references/session-management.md)
+* **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+* **Test generation** [references/test-generation.md](references/test-generation.md)
+* **Tracing** [references/tracing.md](references/tracing.md)
+* **Video recording** [references/video-recording.md](references/video-recording.md)

--- a/.github/skills/playwright-cli/references/request-mocking.md
+++ b/.github/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.github/skills/playwright-cli/references/running-code.md
+++ b/.github/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,232 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.loading', { state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.result', { timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('a.download-link')
+  ]);
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.click('.maybe-missing', { timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.fill('input[name=email]', 'user@example.com');
+  await page.fill('input[name=password]', 'secret');
+  await page.click('button[type=submit]');
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.github/skills/playwright-cli/references/session-management.md
+++ b/.github/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,169 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-b` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.github/skills/playwright-cli/references/storage-state.md
+++ b/.github/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.github/skills/playwright-cli/references/test-generation.md
+++ b/.github/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,88 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your test:
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertion
+await expect(page.getByText('Success')).toBeVisible();
+```

--- a/.github/skills/playwright-cli/references/tracing.md
+++ b/.github/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,139 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM** | Full DOM snapshot before/after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All requests, responses, headers, bodies, timing |
+| **Console** | All console.log, warn, error messages |
+| **Timing** | Precise timing for each operation |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos | Quick capture |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.github/skills/playwright-cli/references/video-recording.md
+++ b/.github/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,43 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Start recording
+playwright-cli video-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop demo.webm
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-stop recordings/login-flow-2024-01-15.webm
+playwright-cli video-stop recordings/checkout-test-run-42.webm
+```
+
+## Tracing vs Video
+
+| Feature | Video | Tracing |
+|---------|-------|---------|
+| Output | WebM file | Trace file (viewable in Trace Viewer) |
+| Shows | Visual recording | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis |
+| Size | Larger | Smaller |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/src/eventstormingboard.client/src/app/_shared/services/auth.service.ts
+++ b/src/eventstormingboard.client/src/app/_shared/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { MsalService } from '@azure/msal-angular';
 import { AuthConfig } from '../models/auth-config.model';
 import { ReplaySubject } from 'rxjs';
@@ -7,10 +7,11 @@ import { ReplaySubject } from 'rxjs';
 export class AuthService {
   private static authConfig: AuthConfig = { enabled: false };
   private _initialized$ = new ReplaySubject<void>(1);
+  private msalService = inject(MsalService, { optional: true });
 
   public initialized$ = this._initialized$.asObservable();
 
-  constructor(private msalService: MsalService | null) {
+  constructor() {
     // MSAL is already initialized and redirect-handled in main.ts before Angular bootstraps.
     // Signal ready immediately so SignalR and other consumers can proceed.
     this._initialized$.next();

--- a/src/eventstormingboard.client/src/app/_shared/services/boards-signalr.service.ts
+++ b/src/eventstormingboard.client/src/app/_shared/services/boards-signalr.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import * as signalR from '@microsoft/signalr';
 import { Subject } from 'rxjs';
 import { BoardContextUpdatedEvent, BoardNameUpdatedEvent, BoundedContextCreatedEvent, BoundedContextDeletedEvent, BoundedContextUpdatedEvent, ConnectionCreatedEvent, CursorPositionUpdatedEvent, NoteCreatedEvent, NoteResizedEvent, NotesDeletedEvent, NotesMovedEvent, NoteTextEditedEvent, PastedEvent, UserJoinedBoardEvent, UserLeftBoardEvent } from '../models/board-events.model';
@@ -42,14 +42,10 @@ export interface AutonomousFacilitatorStatus {
 
 @Injectable({ providedIn: 'root' })
 export class BoardsSignalRService {
-  
+  private authService = inject(AuthService);
   private hubConnection!: signalR.HubConnection;
-  private connectionEstablished: Promise<void>;
+  private connectionEstablished = this.initConnection();
   private pendingJoin: { boardId: string; userName: string } | null = null;
-
-  constructor(private authService: AuthService) {
-    this.connectionEstablished = this.initConnection();
-  }
 
   public connectedUsers$ = new Subject<BoardUser[]>();
   public userJoinedBoard$ = new Subject<UserJoinedBoardEvent>();

--- a/src/eventstormingboard.client/src/app/_shared/services/boards.service.ts
+++ b/src/eventstormingboard.client/src/app/_shared/services/boards.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { BoardCreateDto, BoardDto, BoardSummaryDto } from '../models/board.model';
@@ -9,8 +9,7 @@ import { AgentConfiguration, AgentConfigurationCreate, AgentConfigurationUpdate,
 })
 export class BoardsService {
   private baseUrl = '/api/boards';
-
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
 
   public get(): Observable<BoardSummaryDto[]> {
     return this.http.get<BoardSummaryDto[]>(this.baseUrl);

--- a/src/eventstormingboard.client/src/app/_shared/services/icons.service.ts
+++ b/src/eventstormingboard.client/src/app/_shared/services/icons.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 
@@ -6,12 +6,13 @@ import { DomSanitizer } from '@angular/platform-browser';
   providedIn: 'root'
 })
 export class IconsService {
+  private iconRegistry = inject(MatIconRegistry);
+  private sanitizer = inject(DomSanitizer);
+
   private icons: { name: string; path: string }[] = [
     { name: 'arrow_selector_tool', path: 'icons/arrow_selector_tool.svg' },
     { name: 'database', path: 'icons/database.svg' }
   ];
-
-  constructor(private iconRegistry: MatIconRegistry, private sanitizer: DomSanitizer) {}
 
   public registerIcons(): void {
     this.icons.forEach(icon => {

--- a/src/eventstormingboard.client/src/app/_shared/services/user.service.ts
+++ b/src/eventstormingboard.client/src/app/_shared/services/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { AuthService } from './auth.service';
 
@@ -6,8 +6,9 @@ import { AuthService } from './auth.service';
 export class UserService {
   private readonly storageKey = 'userName';
   private userName$ = new BehaviorSubject<string>(localStorage.getItem(this.storageKey) ?? '');
+  private authService = inject(AuthService);
 
-  constructor(private authService: AuthService) {
+  constructor() {
     // When auth is enabled, override with the Entra ID display name
     if (this.authService.isAuthEnabled) {
       const authName = this.authService.getUserName();

--- a/src/eventstormingboard.client/src/app/app.component.ts
+++ b/src/eventstormingboard.client/src/app/app.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, RouterOutlet } from '@angular/router';
 import { IconsService } from './_shared/services/icons.service';
 import { MatIconModule } from '@angular/material/icon';
@@ -7,7 +8,6 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormsModule } from '@angular/forms';
 import { UserService } from './_shared/services/user.service';
 import { ThemeService } from './_shared/services/theme.service';
-import { Subject, takeUntil } from 'rxjs';
 
 @Component({
     selector: 'app-root',
@@ -21,17 +21,18 @@ import { Subject, takeUntil } from 'rxjs';
     templateUrl: './app.component.html',
     styleUrl: './app.component.scss'
 })
-export class AppComponent implements OnInit, OnDestroy {
+export class AppComponent implements OnInit {
+  private iconsService = inject(IconsService);
+  private router = inject(Router);
+  private userService = inject(UserService);
+  public themeService = inject(ThemeService);
+  private destroyRef = inject(DestroyRef);
+
   public isUserMenuOpen = false;
   public isSettingsMenuOpen = false;
   public userName: string = '';
-  private destroy$ = new Subject<void>();
 
-  constructor(private iconsService: IconsService,
-    private router: Router,
-    private userService: UserService,
-    public themeService: ThemeService
-  ) {
+  constructor() {
     this.iconsService.registerIcons();
   }
 
@@ -40,14 +41,11 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   public ngOnInit(): void {
-    this.userService.displayName$.pipe(takeUntil(this.destroy$)).subscribe(name => {
+    this.userService.displayName$.pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(name => {
       this.userName = name;
     });
-  }
-
-  public ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   public home() {

--- a/src/eventstormingboard.client/src/app/board/agent-config-modal/agent-config-modal.component.ts
+++ b/src/eventstormingboard.client/src/app/board/agent-config-modal/agent-config-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -41,6 +41,10 @@ export interface AgentConfigModalData {
   styleUrls: ['./agent-config-modal.component.scss']
 })
 export class AgentConfigModalComponent implements OnInit {
+  public dialogRef = inject<MatDialogRef<AgentConfigModalComponent>>(MatDialogRef);
+  public data = inject<AgentConfigModalData>(MAT_DIALOG_DATA);
+  private boardsService = inject(BoardsService);
+
   public agents: AgentConfiguration[] = [];
   public availableTools: ToolDefinition[] = [];
   public phases = EVENT_STORMING_PHASES;
@@ -71,12 +75,6 @@ export class AgentConfigModalComponent implements OnInit {
     { value: 'low', label: 'Low' },
     { value: 'medium', label: 'Medium' }
   ];
-
-  constructor(
-    public dialogRef: MatDialogRef<AgentConfigModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: AgentConfigModalData,
-    private boardsService: BoardsService
-  ) {}
 
   ngOnInit(): void {
     this.agents = this.data.agents.map(a => ({ ...a, activePhases: a.activePhases ? [...a.activePhases] : undefined, allowedTools: [...a.allowedTools], canAskAgents: a.canAskAgents ? [...a.canAskAgents] : undefined }));

--- a/src/eventstormingboard.client/src/app/board/agent-interaction-diagram/agent-interaction-diagram.component.ts
+++ b/src/eventstormingboard.client/src/app/board/agent-interaction-diagram/agent-interaction-diagram.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, effect, input, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -33,9 +33,9 @@ const MODIFICATION_TOOLS = ['CreateNote', 'CreateNotes', 'EditNoteText', 'MoveNo
   templateUrl: './agent-interaction-diagram.component.html',
   styleUrls: ['./agent-interaction-diagram.component.scss']
 })
-export class AgentInteractionDiagramComponent implements OnChanges, AfterViewInit {
-  @Input() agents: AgentConfiguration[] = [];
-  @ViewChild('diagramContainer') containerRef!: ElementRef<HTMLDivElement>;
+export class AgentInteractionDiagramComponent implements AfterViewInit {
+  readonly agents = input<AgentConfiguration[]>([]);
+  readonly containerRef = viewChild<ElementRef<HTMLDivElement>>('diagramContainer');
 
   nodes: AgentNode[] = [];
   edges: AgentEdge[] = [];
@@ -47,6 +47,10 @@ export class AgentInteractionDiagramComponent implements OnChanges, AfterViewIni
   orbitRadius = 185;
   private nodeRadius = 36;
   private baseContainerSize = 500;
+  private agentsEffect = effect(() => {
+    this.agents();
+    this.buildGraph();
+  });
 
   ngAfterViewInit(): void {
     setTimeout(() => {
@@ -54,15 +58,10 @@ export class AgentInteractionDiagramComponent implements OnChanges, AfterViewIni
     });
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['agents']) {
-      this.buildGraph();
-    }
-  }
-
   private recalcSize(): void {
-    if (this.containerRef) {
-      const rect = this.containerRef.nativeElement.getBoundingClientRect();
+    const containerRef = this.containerRef();
+    if (containerRef) {
+      const rect = containerRef.nativeElement.getBoundingClientRect();
       if (rect.width > 100 && rect.height > 100) {
         this.baseContainerSize = Math.min(rect.width, rect.height);
         this.svgWidth = Math.min(rect.width, 900);
@@ -75,7 +74,8 @@ export class AgentInteractionDiagramComponent implements OnChanges, AfterViewIni
   }
 
   private buildGraph(): void {
-    if (!this.agents || this.agents.length === 0) return;
+    const agents = this.agents();
+    if (!agents || agents.length === 0) return;
 
     this.computeSizes();
     this.layoutNodes();
@@ -85,7 +85,7 @@ export class AgentInteractionDiagramComponent implements OnChanges, AfterViewIni
 
   /** Scale node and orbit sizes based on agent count so the diagram stays readable */
   private computeSizes(): void {
-    const outerCount = this.agents.filter(a => !a.isFacilitator).length;
+    const outerCount = this.agents().filter(a => !a.isFacilitator).length;
 
     if (outerCount <= 1) {
       this.nodeRadius = 40;
@@ -104,8 +104,9 @@ export class AgentInteractionDiagramComponent implements OnChanges, AfterViewIni
   }
 
   private layoutNodes(): void {
-    const facilitator = this.agents.find(a => a.isFacilitator);
-    const others = this.agents.filter(a => !a.isFacilitator);
+    const agents = this.agents();
+    const facilitator = agents.find(a => a.isFacilitator);
+    const others = agents.filter(a => !a.isFacilitator);
 
     this.nodes = [];
 
@@ -133,15 +134,16 @@ export class AgentInteractionDiagramComponent implements OnChanges, AfterViewIni
 
   private deriveEdges(): void {
     this.edges = [];
-    const agentNames = new Set(this.agents.map(a => a.name));
+    const agents = this.agents();
+    const agentNames = new Set(agents.map(a => a.name));
     const agentsWithModTools = new Set(
-      this.agents.filter(a => a.allowedTools.some(t => MODIFICATION_TOOLS.includes(t))).map(a => a.name)
+      agents.filter(a => a.allowedTools.some(t => MODIFICATION_TOOLS.includes(t))).map(a => a.name)
     );
 
-    for (const agent of this.agents) {
+    for (const agent of agents) {
       // Delegate edges
       if (agent.allowedTools.includes('DelegateToAgent')) {
-        for (const target of this.agents) {
+        for (const target of agents) {
           if (target.name === agent.name) continue;
           if (agentsWithModTools.has(target.name)) {
             this.edges.push({ from: agent.name, to: target.name, type: 'delegate', label: 'Delegate' });
@@ -151,7 +153,7 @@ export class AgentInteractionDiagramComponent implements OnChanges, AfterViewIni
 
       // Review edges
       if (agent.allowedTools.includes('RequestBoardReview')) {
-        for (const target of this.agents) {
+        for (const target of agents) {
           if (target.name === agent.name) continue;
           if (!target.isFacilitator) {
             this.edges.push({ from: agent.name, to: target.name, type: 'review', label: 'Review' });
@@ -163,7 +165,7 @@ export class AgentInteractionDiagramComponent implements OnChanges, AfterViewIni
       if (agent.allowedTools.includes('AskAgentQuestion')) {
         const askTargets = agent.canAskAgents
           ? agent.canAskAgents.filter(n => agentNames.has(n))
-          : this.agents.filter(a => a.name !== agent.name).map(a => a.name);
+          : agents.filter(a => a.name !== agent.name).map(a => a.name);
 
         for (const targetName of askTargets) {
           this.edges.push({ from: agent.name, to: targetName, type: 'ask', label: 'Ask' });

--- a/src/eventstormingboard.client/src/app/board/agent-interaction-diagram/agent-interaction-diagram.component.ts
+++ b/src/eventstormingboard.client/src/app/board/agent-interaction-diagram/agent-interaction-diagram.component.ts
@@ -75,7 +75,12 @@ export class AgentInteractionDiagramComponent implements AfterViewInit {
 
   private buildGraph(): void {
     const agents = this.agents();
-    if (!agents || agents.length === 0) return;
+    if (!agents || agents.length === 0) {
+      this.nodes = [];
+      this.edges = [];
+      this.bundledEdges = [];
+      return;
+    }
 
     this.computeSizes();
     this.layoutNodes();

--- a/src/eventstormingboard.client/src/app/board/ai-chat-panel/ai-chat-panel.component.html
+++ b/src/eventstormingboard.client/src/app/board/ai-chat-panel/ai-chat-panel.component.html
@@ -5,13 +5,13 @@
       <mat-icon class="chat-header-icon" fontSet="material-icons-outlined">smart_toy</mat-icon>
       <div class="chat-header-title-area">
         <span class="chat-title">AI Assistant</span>
-        <span class="autonomy-badge" [class.active]="autonomousEnabled" [class.running]="autonomousStatus?.isRunning">
+        <span class="autonomy-badge" [class.active]="autonomousEnabled()" [class.running]="autonomousStatus()?.isRunning">
           {{ autonomousStatusLabel }}
         </span>
       </div>
     </div>
     <div class="chat-header-actions">
-      @if (autonomousEnabled) {
+      @if (autonomousEnabled()) {
       <button mat-icon-button (click)="disableAutonomousRequested.emit()" matTooltip="Stop autonomous facilitator">
         <mat-icon>pause_circle</mat-icon>
       </button>

--- a/src/eventstormingboard.client/src/app/board/ai-chat-panel/ai-chat-panel.component.ts
+++ b/src/eventstormingboard.client/src/app/board/ai-chat-panel/ai-chat-panel.component.ts
@@ -1,11 +1,11 @@
-import { Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, Pipe, PipeTransform, SimpleChanges, ViewChild, HostListener } from '@angular/core';
+import { Component, DestroyRef, ElementRef, HostListener, OnInit, Pipe, PipeTransform, effect, inject, input, output, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { BoardsSignalRService, AgentChatMessage, AgentToolCallStartedEvent, AutonomousFacilitatorStatus } from '../../_shared/services/boards-signalr.service';
-import { Subject, takeUntil } from 'rxjs';
+import { BoardsSignalRService, AgentChatMessage, AutonomousFacilitatorStatus } from '../../_shared/services/boards-signalr.service';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { AgentConfiguration } from '../../_shared/models/agent-configuration.model';
@@ -44,17 +44,18 @@ const DEFAULT_AGENT: AgentDisplayInfo = { label: 'AI Assistant', icon: 'smart_to
   templateUrl: './ai-chat-panel.component.html',
   styleUrls: ['./ai-chat-panel.component.scss']
 })
-export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
-  @Input() boardId!: string;
-  @Input() userName!: string;
-  @Input() autonomousEnabled = false;
-  @Input() autonomousStatus?: AutonomousFacilitatorStatus;
-  @Input() agentConfigurations: AgentConfiguration[] = [];
-  @Output() closed = new EventEmitter<void>();
-  @Output() disableAutonomousRequested = new EventEmitter<void>();
-  @ViewChild('messagesContainer') private messagesContainer!: ElementRef<HTMLDivElement>;
+export class AiChatPanelComponent implements OnInit {
+  readonly boardId = input.required<string>();
+  readonly userName = input.required<string>();
+  readonly autonomousEnabled = input(false);
+  readonly autonomousStatus = input<AutonomousFacilitatorStatus | undefined>();
+  readonly agentConfigurations = input<AgentConfiguration[]>([]);
+  readonly closed = output<void>();
+  readonly disableAutonomousRequested = output<void>();
+  private messagesContainer = viewChild<ElementRef<HTMLDivElement>>('messagesContainer');
 
-  private destroy$ = new Subject<void>();
+  private signalRService = inject(BoardsSignalRService);
+  private destroyRef = inject(DestroyRef);
 
   public messages: ChatMessage[] = [];
   public activeToolCalls: { name: string; arguments: string }[] = [];
@@ -66,18 +67,14 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
   private startX = 0;
   private startWidth = 0;
   private agentDisplayMap = new Map<string, AgentDisplayInfo>();
-
-  constructor(private signalRService: BoardsSignalRService) { }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['agentConfigurations']) {
-      this.rebuildAgentDisplayMap();
-    }
-  }
+  private agentConfigEffect = effect(() => {
+    this.agentConfigurations();
+    this.rebuildAgentDisplayMap();
+  });
 
   private rebuildAgentDisplayMap(): void {
     this.agentDisplayMap.clear();
-    for (const config of this.agentConfigurations) {
+    for (const config of this.agentConfigurations()) {
       this.agentDisplayMap.set(config.name, {
         label: config.name,
         icon: config.icon,
@@ -88,8 +85,8 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
 
   ngOnInit(): void {
     // Always request fresh history from server for the current board.
-    this.signalRService.getAgentHistory(this.boardId).then(() => {
-      const cached = this.signalRService.getHistoryForBoard(this.boardId);
+    this.signalRService.getAgentHistory(this.boardId()).then(() => {
+      const cached = this.signalRService.getHistoryForBoard(this.boardId());
       if (cached.length > 0) {
         this.messages = cached.map(m => this.mapToDisplayMessage(m));
         this.scrollToBottom();
@@ -97,17 +94,17 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
     });
 
     this.signalRService.agentUserMessage$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(msg => {
-        if (msg.boardId && msg.boardId !== this.boardId) return;
+        if (msg.boardId && msg.boardId !== this.boardId()) return;
         this.messages.push(this.mapToDisplayMessage(msg));
         this.scrollToBottom();
       });
 
     this.signalRService.agentResponse$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(msg => {
-        if (msg.boardId && msg.boardId !== this.boardId) return;
+        if (msg.boardId && msg.boardId !== this.boardId()) return;
         this.loading = false;
         this.activeToolCalls = [];
         this.messages.push(this.mapToDisplayMessage(msg));
@@ -115,9 +112,9 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
       });
 
     this.signalRService.agentStepUpdate$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(msg => {
-        if (msg.boardId && msg.boardId !== this.boardId) return;
+        if (msg.boardId && msg.boardId !== this.boardId()) return;
         const display = this.mapToDisplayMessage(msg);
         // Replace-or-append: if a message with this stepId exists, replace it in-place.
         if (display.stepId) {
@@ -133,17 +130,17 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
       });
 
     this.signalRService.agentChatComplete$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(boardId => {
-        if (boardId && boardId !== this.boardId) return;
+        if (boardId && boardId !== this.boardId()) return;
         this.loading = false;
         this.activeToolCalls = [];
       });
 
     this.signalRService.agentToolCallStarted$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
-        if (event.boardId && event.boardId !== this.boardId) return;
+        if (event.boardId && event.boardId !== this.boardId()) return;
         if (this.loading) {
           const args = Object.entries(event.arguments ?? {})
             .map(([k, v]) => `${k}: ${v}`)
@@ -154,18 +151,13 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
       });
 
     this.signalRService.agentHistoryCleared$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(boardId => {
-        if (boardId && boardId !== this.boardId) return;
+        if (boardId && boardId !== this.boardId()) return;
         this.messages = [];
         this.activeToolCalls = [];
         this.loading = false;
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   public send(): void {
@@ -175,11 +167,11 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
     this.input = '';
     this.loading = true;
     this.activeToolCalls = [];
-    this.signalRService.sendAgentMessage(this.boardId, text);
+    this.signalRService.sendAgentMessage(this.boardId(), text);
   }
 
   public clearHistory(): void {
-    this.signalRService.clearAgentHistory(this.boardId);
+    this.signalRService.clearAgentHistory(this.boardId());
   }
 
   public onKeydown(event: KeyboardEvent): void {
@@ -190,7 +182,7 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   public isOwnMessage(msg: ChatMessage): boolean {
-    return msg.role === 'user' && msg.userName === this.userName;
+    return msg.role === 'user' && msg.userName === this.userName();
   }
 
   public aggregateToolCalls(toolCalls: { name: string; arguments: string }[]): { name: string; count: number, active: boolean }[] {
@@ -204,19 +196,19 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   public get autonomousStatusLabel(): string {
-    if (!this.autonomousEnabled) {
+    if (!this.autonomousEnabled()) {
       return 'Autonomy off';
     }
 
-    if (this.autonomousStatus?.isRunning) {
+    if (this.autonomousStatus()?.isRunning) {
       return 'Autonomy working';
     }
 
-    if (this.autonomousStatus?.stopReason === 'noActiveUsers') {
+    if (this.autonomousStatus()?.stopReason === 'noActiveUsers') {
       return 'Paused: no users';
     }
 
-    if (this.autonomousStatus?.stopReason === 'failureLimitExceeded') {
+    if (this.autonomousStatus()?.stopReason === 'failureLimitExceeded') {
       return 'Paused after errors';
     }
 
@@ -241,7 +233,7 @@ export class AiChatPanelComponent implements OnInit, OnDestroy, OnChanges {
 
   private scrollToBottom(): void {
     setTimeout(() => {
-      const el = this.messagesContainer?.nativeElement;
+      const el = this.messagesContainer()?.nativeElement;
       if (el) el.scrollTop = el.scrollHeight;
     });
   }

--- a/src/eventstormingboard.client/src/app/board/ai-chat-panel/ai-chat-panel.component.ts
+++ b/src/eventstormingboard.client/src/app/board/ai-chat-panel/ai-chat-panel.component.ts
@@ -68,20 +68,16 @@ export class AiChatPanelComponent implements OnInit {
   private startWidth = 0;
   private agentDisplayMap = new Map<string, AgentDisplayInfo>();
   private agentConfigEffect = effect(() => {
-    this.agentConfigurations();
-    this.rebuildAgentDisplayMap();
-  });
-
-  private rebuildAgentDisplayMap(): void {
+    const configs = this.agentConfigurations();
     this.agentDisplayMap.clear();
-    for (const config of this.agentConfigurations()) {
+    for (const config of configs) {
       this.agentDisplayMap.set(config.name, {
         label: config.name,
         icon: config.icon,
         color: config.color
       });
     }
-  }
+  });
 
   ngOnInit(): void {
     // Always request fresh history from server for the current board.

--- a/src/eventstormingboard.client/src/app/board/board-canvas/bc-name-modal/bc-name-modal.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board-canvas/bc-name-modal/bc-name-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -20,11 +20,8 @@ import { MatButtonModule } from '@angular/material/button';
     styleUrls: ['./bc-name-modal.component.scss']
 })
 export class BcNameModalComponent {
-
-  constructor(
-    public dialogRef: MatDialogRef<BcNameModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: { name: string }
-  ) {}
+  public dialogRef = inject<MatDialogRef<BcNameModalComponent>>(MatDialogRef);
+  public data = inject<{ name: string }>(MAT_DIALOG_DATA);
 
   public onCancel(): void {
     this.dialogRef.close();

--- a/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
@@ -551,6 +551,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit {
 
   @HostListener('window:resize')
   public onResize(): void {
+    if (!this.ctx) return;
     this.canvas().nativeElement.width = window.innerWidth;
     this.canvas().nativeElement.height = window.innerHeight;
     this.drawCanvas();

--- a/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
@@ -1,4 +1,5 @@
-import { AfterViewInit, Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, DestroyRef, ElementRef, HostListener, OnInit, inject, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Note, getNoteColor } from '../../_shared/models/note.model';
 import { Connection } from '../../_shared/models/connection.model';
 import { BoundedContext } from '../../_shared/models/bounded-context.model';
@@ -11,7 +12,6 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { NoteTextModalComponent } from './note-text-modal/note-text-modal.component';
 import { BcNameModalComponent } from './bc-name-modal/bc-name-modal.component';
 import { BoardCanvasService } from './board-canvas.service';
-import { Subject, takeUntil } from 'rxjs';
 import { KeyboardShortcutsModalComponent } from '../keyboard-shortcuts-modal/keyboard-shortcuts-modal.component';
 import { BoardsSignalRService } from '../../_shared/services/boards-signalr.service';
 import { BoardUser } from '../../_shared/models/board-user.model';
@@ -27,11 +27,16 @@ import { UserService } from '../../_shared/services/user.service';
     templateUrl: './board-canvas.component.html',
     styleUrls: ['./board-canvas.component.scss']
 })
-export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
+export class BoardCanvasComponent implements OnInit, AfterViewInit {
 
   private static readonly CURSOR_BROADCAST_INTERVAL_MS = 50;
 
-  private destroy$ = new Subject<void>();
+  private dialog = inject(MatDialog);
+  private canvasService = inject(BoardCanvasService);
+  private boardsHub = inject(BoardsSignalRService);
+  private themeService = inject(ThemeService);
+  private userService = inject(UserService);
+  private destroyRef = inject(DestroyRef);
 
   private ctx!: CanvasRenderingContext2D;
   private minimapCtx!: CanvasRenderingContext2D;
@@ -80,23 +85,12 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
   private bcInitialResizeState: { x: number; y: number; width: number; height: number } | null = null;
   private bcInitialDragPosition: { x: number; y: number } | null = null;
 
-  @ViewChild('canvas', { static: true })
-  public canvas!: ElementRef<HTMLCanvasElement>;
+  public canvas = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
 
-  @ViewChild('minimap', { static: true })
-  public minimap!: ElementRef<HTMLCanvasElement>;
-
-  constructor(
-    private dialog: MatDialog,
-    private canvasService: BoardCanvasService,
-    private boardsHub: BoardsSignalRService,
-    private themeService: ThemeService,
-    private userService: UserService
-  ) {
-  }
+  public minimap = viewChild.required<ElementRef<HTMLCanvasElement>>('minimap');
 
   public onMinimapClick(event: MouseEvent): void {
-    const rect = this.minimap.nativeElement.getBoundingClientRect();
+    const rect = this.minimap().nativeElement.getBoundingClientRect();
     const clickX = event.clientX - rect.left;
     const clickY = event.clientY - rect.top;
 
@@ -105,7 +99,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
     const canvasX = clickX / dynamicScale + minX;
     const canvasY = clickY / dynamicScale + minY;
 
-    const canvasEl = this.canvas.nativeElement;
+    const canvasEl = this.canvas().nativeElement;
     this.canvasService.originX = -canvasX * this.canvasService.scale + canvasEl.width / 2;
     this.canvasService.originY = -canvasY * this.canvasService.scale + canvasEl.height / 2;
 
@@ -403,7 +397,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
       // Ctrl pressed: Zooming behavior  
       event.preventDefault();
 
-      const rect = this.canvas.nativeElement.getBoundingClientRect();
+      const rect = this.canvas().nativeElement.getBoundingClientRect();
       const screenX = event.clientX - rect.left;
       const screenY = event.clientY - rect.top;
 
@@ -551,32 +545,32 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.handleTemporaryArrow(event)) return;
 
     this.updateHoverState();
-    this.canvas.nativeElement.style.cursor = this.getCursorStyle();
+    this.canvas().nativeElement.style.cursor = this.getCursorStyle();
     this.drawCanvas();
   }
 
   @HostListener('window:resize')
   public onResize(): void {
-    this.canvas.nativeElement.width = window.innerWidth;
-    this.canvas.nativeElement.height = window.innerHeight;
+    this.canvas().nativeElement.width = window.innerWidth;
+    this.canvas().nativeElement.height = window.innerHeight;
     this.drawCanvas();
   }
 
   public ngOnInit(): void {
     this.canvasService.canvasUpdated$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.drawCanvas();
       });
 
     this.canvasService.canvasImageDownloaded$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.exportBoardAsImage();
       });
 
     this.themeService.theme$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         if (this.ctx) {
           this.drawCanvas();
@@ -588,24 +582,19 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
     this.generateCanvas();
   }
 
-  public ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
   private generateCanvas(): void {
-    this.ctx = this.canvas.nativeElement.getContext('2d')!;
-    this.canvas.nativeElement.width = window.innerWidth;
-    this.canvas.nativeElement.height = window.innerHeight;
+    this.ctx = this.canvas().nativeElement.getContext('2d')!;
+    this.canvas().nativeElement.width = window.innerWidth;
+    this.canvas().nativeElement.height = window.innerHeight;
 
-    this.minimapCtx = this.minimap.nativeElement.getContext('2d')!;
-    this.minimap.nativeElement.width = 260;
-    this.minimap.nativeElement.height = 185;
+    this.minimapCtx = this.minimap().nativeElement.getContext('2d')!;
+    this.minimap().nativeElement.width = 260;
+    this.minimap().nativeElement.height = 185;
     this.drawCanvas();
   }
 
   private exportBoardAsImage(): void {
-    const canvasEl = this.canvas.nativeElement;
+    const canvasEl = this.canvas().nativeElement;
     const tempCanvas = document.createElement('canvas');
     const tempCtx = tempCanvas.getContext('2d')!;
 
@@ -688,7 +677,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private drawCanvasFrame(): void {
-    const canvasEl = this.canvas.nativeElement;
+    const canvasEl = this.canvas().nativeElement;
     const T = this.theme;
     this.ctx.setTransform(this.canvasService.scale, 0, 0, this.canvasService.scale, this.canvasService.originX, this.canvasService.originY);
 
@@ -921,7 +910,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private drawMinimap(): void {
     const T = this.theme;
-    const minimapCanvas = this.minimap.nativeElement;
+    const minimapCanvas = this.minimap().nativeElement;
     const ctx = this.minimapCtx;
 
     // Dark minimap background
@@ -973,8 +962,8 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
     const viewportRect = {
       x: (-this.canvasService.originX) / this.canvasService.scale,
       y: (-this.canvasService.originY) / this.canvasService.scale,
-      width: this.canvas.nativeElement.width / this.canvasService.scale,
-      height: this.canvas.nativeElement.height / this.canvasService.scale
+      width: this.canvas().nativeElement.width / this.canvasService.scale,
+      height: this.canvas().nativeElement.height / this.canvasService.scale
     };
 
     ctx.strokeStyle = T.primaryContainer;
@@ -988,7 +977,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private getCanvasBoundsAndScale() {
-    const minimapCanvas = this.minimap.nativeElement;
+    const minimapCanvas = this.minimap().nativeElement;
 
     if (this.canvasService.boardState.notes.length === 0 && this.canvasService.boardState.boundedContexts.length === 0) {
       return {
@@ -1262,7 +1251,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private getMousePos(event: MouseEvent | WheelEvent): Coordinates {
-    const rect = this.canvas.nativeElement.getBoundingClientRect();
+    const rect = this.canvas().nativeElement.getBoundingClientRect();
     return {
       x: (event.clientX - rect.left - this.canvasService.originX) / this.canvasService.scale,
       y: (event.clientY - rect.top - this.canvasService.originY) / this.canvasService.scale
@@ -1454,7 +1443,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
       this.lastPanX = event.clientX;
       this.lastPanY = event.clientY;
 
-      this.canvas.nativeElement.style.cursor = 'grab';
+      this.canvas().nativeElement.style.cursor = 'grab';
       this.drawCanvas();
       return true;
     }
@@ -1515,7 +1504,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
           break;
       }
 
-      this.canvas.nativeElement.style.cursor = `${this.resizeCorner}-resize`;
+      this.canvas().nativeElement.style.cursor = `${this.resizeCorner}-resize`;
       this.drawCanvas();
       return true;
     }
@@ -1532,7 +1521,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
         note.y += deltaY;
       });
 
-      this.canvas.nativeElement.style.cursor = 'move';
+      this.canvas().nativeElement.style.cursor = 'move';
       this.drawCanvas();
       return true;
     }
@@ -1547,7 +1536,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
         width: Math.abs(this.currentMousePos.x - this.selectionStart.x),
         height: Math.abs(this.currentMousePos.y - this.selectionStart.y)
       };
-      this.canvas.nativeElement.style.cursor = 'crosshair';
+      this.canvas().nativeElement.style.cursor = 'crosshair';
       this.drawCanvas();
       return true;
     }
@@ -1570,7 +1559,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
           break;
         }
       }
-      this.canvas.nativeElement.style.cursor = foundHover ? 'crosshair' : 'default';
+      this.canvas().nativeElement.style.cursor = foundHover ? 'crosshair' : 'default';
       this.drawCanvas();
       return true;
     }
@@ -1581,7 +1570,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
   private handleTemporaryArrow(event: MouseEvent): boolean {
     if (this.canvasService.isDrawingConnection) {
       this.drawTemporaryArrow(event);
-      this.canvas.nativeElement.style.cursor = 'crosshair';
+      this.canvas().nativeElement.style.cursor = 'crosshair';
       return true;
     }
     return false;

--- a/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts
+++ b/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { BoardState } from '../../_shared/models/board-state.model';
 import { Subject } from 'rxjs';
 import { BoardsSignalRService } from '../../_shared/services/boards-signalr.service';
@@ -9,14 +9,10 @@ import { RemoteCursorState } from '../../_shared/models/remote-cursor-state.mode
 
 @Injectable()
 export class BoardCanvasService {
+  private boardsHub = inject(BoardsSignalRService);
 
   private undoStack: Command<BoardState>[] = [];
   private redoStack: Command<BoardState>[] = [];
-
-  constructor(
-    private boardsHub: BoardsSignalRService
-  ) {
-  }
 
   public boardState: BoardState = {
     notes: [],

--- a/src/eventstormingboard.client/src/app/board/board-canvas/note-text-modal/note-text-modal.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board-canvas/note-text-modal/note-text-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -20,11 +20,8 @@ import { MatButtonModule } from '@angular/material/button';
     styleUrls: ['./note-text-modal.component.scss']
 })
 export class NoteTextModalComponent {
-
-  constructor(
-    public dialogRef: MatDialogRef<NoteTextModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: { text: string }
-  ) {}
+  public dialogRef = inject<MatDialogRef<NoteTextModalComponent>>(MatDialogRef);
+  public data = inject<{ text: string }>(MAT_DIALOG_DATA);
 
   public onCancel(): void {
     this.dialogRef.close();

--- a/src/eventstormingboard.client/src/app/board/board-context-modal/board-context-modal.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board-context-modal/board-context-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -31,11 +31,8 @@ export interface BoardContextData {
 })
 export class BoardContextModalComponent {
   public phases = EVENT_STORMING_PHASES;
-
-  constructor(
-    public dialogRef: MatDialogRef<BoardContextModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: BoardContextData
-  ) { }
+  public dialogRef = inject<MatDialogRef<BoardContextModalComponent>>(MatDialogRef);
+  public data = inject<BoardContextData>(MAT_DIALOG_DATA);
 
   public onCancel(): void {
     this.dialogRef.close();

--- a/src/eventstormingboard.client/src/app/board/board.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, DestroyRef, OnDestroy, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Note, getNoteColor } from '../_shared/models/note.model';
 import { CreateConnectionCommand, CreateBoundedContextCommand, CreateNoteCommand, DeleteBoundedContextCommand, DeleteNotesCommand, EditNoteTextCommand, MoveBoundedContextCommand, MoveNotesCommand, PasteCommand, ResizeBoundedContextCommand, ResizeNoteCommand, UpdateBoardContextCommand, UpdateBoardNameCommand, UpdateBoundedContextCommand } from './board.commands';
 import { v4 as uuid } from 'uuid';
 import { AutonomousFacilitatorStatus, BoardsSignalRService } from '../_shared/services/boards-signalr.service';
-import { Subject, takeUntil } from 'rxjs';
 import { MatButtonModule } from '@angular/material/button';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
@@ -56,19 +56,18 @@ interface ImportedBoardState {
 export class BoardComponent implements OnInit, OnDestroy {
 
   private static readonly CURSOR_STALE_TIMEOUT_MS = 15000;
-  private destroy$ = new Subject<void>();
+  private boardsHub = inject(BoardsSignalRService);
+  public canvasService = inject(BoardCanvasService);
+  private activatedRoute = inject(ActivatedRoute);
+  private boardsService = inject(BoardsService);
+  private dialog = inject(MatDialog);
+  private userService = inject(UserService);
+  private destroyRef = inject(DestroyRef);
   private id!: string;
   public userName: string;
   private previousName: string;
 
-  constructor(
-    private boardsHub: BoardsSignalRService,
-    public canvasService: BoardCanvasService,
-    private activatedRoute: ActivatedRoute,
-    private boardsService: BoardsService,
-    private dialog: MatDialog,
-    private userService: UserService
-  ) {
+  constructor() {
     this.canvasService.boardState = {
       name: '',
       autonomousEnabled: false,
@@ -693,24 +692,22 @@ export class BoardComponent implements OnInit, OnDestroy {
   public ngOnDestroy(): void {
     this.boardsHub.leaveBoard(this.id);
     this.canvasService.remoteCursors.clear();
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private subscribeToEvents(): void {
     this.boardsHub.connectedUsers$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(users => {
         this.connectedUsers = users.filter(user => user.boardId === this.id)
           .map(user => new BoardUser(user.boardId, user.userName, user.connectionId));
       });
     this.boardsHub.userJoinedBoard$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.connectedUsers.push(new BoardUser(event.boardId, event.userName, event.connectionId));
       });
     this.boardsHub.userLeftBoard$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.connectedUsers = this.connectedUsers.filter(user => user.connectionId !== event.connectionId);
         this.canvasService.remoteCursors.delete(event.connectionId);
@@ -718,7 +715,7 @@ export class BoardComponent implements OnInit, OnDestroy {
       });
 
     this.boardsHub.cursorPositionUpdated$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((event: CursorPositionUpdatedEvent) => {
         if (event.boardId !== this.id || !this.isValidCursorEvent(event)) {
           return;
@@ -735,13 +732,13 @@ export class BoardComponent implements OnInit, OnDestroy {
         this.canvasService.drawCanvas();
       });
     this.boardsHub.boardNameUpdated$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new UpdateBoardNameCommand(event.newName, event.oldName), true, event.isUndo);
       });
 
     this.boardsHub.boardContextUpdated$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(
           new UpdateBoardContextCommand(
@@ -753,55 +750,55 @@ export class BoardComponent implements OnInit, OnDestroy {
       });
 
     this.boardsHub.noteAdded$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new CreateNoteCommand(event.note), true, event.isUndo);
       });
 
     this.boardsHub.notesMoved$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new MoveNotesCommand(event.from, event.to), true, event.isUndo);
       });
 
     this.boardsHub.noteResized$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new ResizeNoteCommand(event.noteId, event.from, event.to), true, event.isUndo);
       });
 
     this.boardsHub.notesDeleted$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new DeleteNotesCommand(event.notes, event.connections), true, event.isUndo);
       });
 
     this.boardsHub.connectionCreated$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new CreateConnectionCommand(event.connection), true, event.isUndo);
       });
 
     this.boardsHub.noteTextEdited$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new EditNoteTextCommand(event.noteId, event.toText, event.fromText), true, event.isUndo);
       });
 
     this.boardsHub.pasted$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new PasteCommand(event.notes, event.connections), true, event.isUndo);
       });
 
     this.boardsHub.boundedContextCreated$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new CreateBoundedContextCommand(event.boundedContext), true, event.isUndo);
       });
 
     this.boardsHub.boundedContextUpdated$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(
           new UpdateBoundedContextCommand(
@@ -815,13 +812,13 @@ export class BoardComponent implements OnInit, OnDestroy {
       });
 
     this.boardsHub.boundedContextDeleted$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         this.canvasService.executeCommand(new DeleteBoundedContextCommand(event.boundedContext), true, event.isUndo);
       });
 
     this.boardsHub.agentUserMessage$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         if (!this.isChatOpen && event.userName !== this.userName) {
           this.hasUnreadMessages = true;
@@ -829,13 +826,13 @@ export class BoardComponent implements OnInit, OnDestroy {
       });
 
     this.boardsHub.agentStepUpdate$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         if (!this.isChatOpen) this.hasUnreadMessages = true;
       });
 
     this.boardsHub.autonomousStatusChanged$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(status => {
         if (status.boardId === this.id) {
           this.autonomousStatus = status;
@@ -848,7 +845,7 @@ export class BoardComponent implements OnInit, OnDestroy {
       });
 
     this.boardsHub.agentConfigurationsUpdated$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(event => {
         if (event.boardId === this.id) {
           this.agentConfigurations = event.agents;
@@ -858,7 +855,7 @@ export class BoardComponent implements OnInit, OnDestroy {
 
   private startPruningCursors(): void {
     const intervalId = setInterval(() => this.pruneStaleRemoteCursors(), 2000);
-    this.destroy$.subscribe(() => clearInterval(intervalId));
+    this.destroyRef.onDestroy(() => clearInterval(intervalId));
   }
 
   private pruneStaleRemoteCursors(): void {

--- a/src/eventstormingboard.client/src/app/board/keyboard-shortcuts-modal/keyboard-shortcuts-modal.component.ts
+++ b/src/eventstormingboard.client/src/app/board/keyboard-shortcuts-modal/keyboard-shortcuts-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
@@ -15,6 +15,8 @@ type ShortcutSection = {
   styleUrls: ['./keyboard-shortcuts-modal.component.scss']
 })
 export class KeyboardShortcutsModalComponent {
+  public dialogRef = inject<MatDialogRef<KeyboardShortcutsModalComponent>>(MatDialogRef);
+
   public readonly sections: ShortcutSection[] = [
     {
       title: 'Editing',
@@ -46,5 +48,4 @@ export class KeyboardShortcutsModalComponent {
     }
   ];
 
-  constructor(public dialogRef: MatDialogRef<KeyboardShortcutsModalComponent>) {}
 }

--- a/src/eventstormingboard.client/src/app/splash/create-board-modal/create-board-modal.component.ts
+++ b/src/eventstormingboard.client/src/app/splash/create-board-modal/create-board-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -21,15 +21,13 @@ import { BoardsService } from '../../_shared/services/boards.service';
     styleUrls: ['./create-board-modal.component.scss']
 })
 export class CreateBoardModalComponent {
-  constructor(
-    public dialogRef: MatDialogRef<CreateBoardModalComponent>,
-    private boardsService: BoardsService,
-    @Inject(MAT_DIALOG_DATA) public data: {
-      name: string;
-      domain?: string;
-      sessionScope?: string;
-    }
-  ) { }
+  public dialogRef = inject<MatDialogRef<CreateBoardModalComponent>>(MatDialogRef);
+  private boardsService = inject(BoardsService);
+  public data = inject<{
+    name: string;
+    domain?: string;
+    sessionScope?: string;
+  }>(MAT_DIALOG_DATA);
 
   public onCancel(): void {
     this.dialogRef.close();

--- a/src/eventstormingboard.client/src/app/splash/select-board-modal/select-board-modal.component.ts
+++ b/src/eventstormingboard.client/src/app/splash/select-board-modal/select-board-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -24,14 +24,12 @@ import { MatSelectModule } from '@angular/material/select';
     styleUrls: ['./select-board-modal.component.scss']
 })
 export class SelectBoardModalComponent implements OnInit {
+  public dialogRef = inject<MatDialogRef<SelectBoardModalComponent>>(MatDialogRef);
+  private boardsService = inject(BoardsService);
+  public data = inject<{ id: string }>(MAT_DIALOG_DATA);
+
   boards: BoardSummaryDto[] = [];
   selectedBoardId: string | null = null;
-
-  constructor(
-    public dialogRef: MatDialogRef<SelectBoardModalComponent>,
-    private boardsService: BoardsService,
-    @Inject(MAT_DIALOG_DATA) public data: { id: string }
-  ) { }
 
   ngOnInit(): void {
     this.boardsService.get().subscribe({

--- a/src/eventstormingboard.client/src/app/splash/splash.component.ts
+++ b/src/eventstormingboard.client/src/app/splash/splash.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatIconModule } from '@angular/material/icon';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -6,7 +7,6 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { CreateBoardModalComponent } from './create-board-modal/create-board-modal.component';
 import { SelectBoardModalComponent } from './select-board-modal/select-board-modal.component';
 import { UserService } from '../_shared/services/user.service';
-import { Subject, takeUntil } from 'rxjs';
 
 @Component({
     selector: 'app-splash',
@@ -18,15 +18,14 @@ import { Subject, takeUntil } from 'rxjs';
     templateUrl: './splash.component.html',
     styleUrls: ['./splash.component.scss']
 })
-export class SplashComponent implements OnInit, OnDestroy {
+export class SplashComponent implements OnInit {
+
+  private router = inject(Router);
+  private dialog = inject(MatDialog);
+  private userService = inject(UserService);
+  private destroyRef = inject(DestroyRef);
 
   public userName: string = '';
-  private destroy$ = new Subject<void>();
-
-  constructor(
-    private router: Router,
-    private dialog: MatDialog,
-    private userService: UserService) { }
 
   public get isNameReadOnly(): boolean {
     return this.userService.isReadOnly;
@@ -69,13 +68,10 @@ export class SplashComponent implements OnInit, OnDestroy {
   }
 
   public ngOnInit(): void {
-    this.userService.displayName$.pipe(takeUntil(this.destroy$)).subscribe(name => {
+    this.userService.displayName$.pipe(
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(name => {
       this.userName = name;
     });
-  }
-
-  public ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }  


### PR DESCRIPTION
Closes #24

Modernizes the Angular frontend by migrating all services and components from constructor injection to `inject()`, adopting `takeUntilDestroyed()`, and converting to signal-based I/O (`input()`, `output()`, `viewChild()`, `effect()`) where applicable.