### PR TITLE
Click Phase on Phase Stepper

### DIFF
--- a/.agent-context/knowledge/user-journeys.md
+++ b/.agent-context/knowledge/user-journeys.md
@@ -189,7 +189,16 @@ Toolbar buttons use CSS class `.tool-btn`. Active state: `.active` class.
 | 4 | `"4"` | Define Aggregates | `DefineAggregates` |
 | 5 | `"5"` | Break It Down | `BreakItDown` |
 
-Phase steps are clickable. Container: `progressbar "Event Storming Phase"`. Individual steps have class `.step` with `.active` for the current phase.
+Phase steps are clickable — clicking a step changes the board's active workshop phase (uses `UpdateBoardContextCommand` → SignalR broadcast). Clicking the already-active step is a no-op. Steps are keyboard-accessible (Enter/Space) with `:focus-visible` outline styling.
+
+Container: `group "Event Storming Phase"`. Individual steps have `role="button"`, `tabindex="0"`, class `.step` with `.active` for the current phase.
+
+| Attribute | Value |
+|-----------|-------|
+| `role` | `button` |
+| `aria-label` | `Go to phase: {label}` (e.g., "Go to phase: Identify Events") |
+| `aria-current` | `step` (on active step only) |
+| `aria-disabled` | `true` (on active step only) |
 
 ### Bottom Controls
 

--- a/.agent-context/tasks/click-phase-stepper/phase-1-clickable-phase-steps.md
+++ b/.agent-context/tasks/click-phase-stepper/phase-1-clickable-phase-steps.md
@@ -1,0 +1,132 @@
+# Phase 1: Clickable Phase Steps
+
+**Objective**: Make each step in the phase stepper clickable, triggering a phase change via the existing `UpdateBoardContextCommand` → SignalR pipeline.
+**Files to modify**:
+- `src/eventstormingboard.client/src/app/board/board.component.html` — add `(click)` and `(keydown)` handlers, `tabindex`, ARIA attributes on each step
+- `src/eventstormingboard.client/src/app/board/board.component.ts` — add `onPhaseClick()` method
+- `src/eventstormingboard.client/src/app/board/board.component.scss` — add focus-visible styles for keyboard navigation
+
+## Context
+
+The phase stepper template iterates `EVENT_STORMING_PHASES` and renders `.step` divs with an `.active` class. The existing `openBoardContext()` method already demonstrates the exact pattern for creating an `UpdateBoardContextCommand` and executing it via `canvasService.executeCommand()`. This phase replicates that pattern with a targeted method that only changes the phase field, preserving all other board context values.
+
+## Knowledge, Instructions & Skills
+
+- `.github/instructions/angular.instructions.md` — standalone component conventions, signal patterns, `takeUntilDestroyed()`
+- `.github/skills/frontend-design/SKILL.md` — Kinetic Ionization design system for focus/hover styles (zero radius, primary color tokens)
+
+## Implementation Steps
+
+### Step 1: Add `onPhaseClick()` method to `board.component.ts`
+
+Add a new public method after the existing `isPhaseActive()` method (around line 102). The method should:
+1. Check if the clicked phase is already active — return early if so (FR-5)
+2. Create an `UpdateBoardContextCommand` preserving all current board context values, only changing the phase
+3. Execute the command via `canvasService.executeCommand()`
+
+**Code example:**
+```typescript
+public onPhaseClick(phase: string): void {
+  if (this.isPhaseActive(phase)) {
+    return;
+  }
+  const command = new UpdateBoardContextCommand(
+    this.canvasService.boardState.domain,
+    this.canvasService.boardState.domain,
+    this.canvasService.boardState.sessionScope,
+    this.canvasService.boardState.sessionScope,
+    phase,
+    this.canvasService.boardState.phase,
+    this.canvasService.boardState.autonomousEnabled,
+    this.canvasService.boardState.autonomousEnabled
+  );
+  this.canvasService.executeCommand(command);
+}
+```
+
+**Reference**: `src/eventstormingboard.client/src/app/board/board.component.ts` lines 468–495 — the `openBoardContext()` method uses the same `UpdateBoardContextCommand` constructor and `canvasService.executeCommand()` call pattern. The key difference: `onPhaseClick()` preserves domain, sessionScope, and autonomousEnabled unchanged (old === new), only changing the phase.
+
+**Reference**: `src/eventstormingboard.client/src/app/board/board.commands.ts` — `UpdateBoardContextCommand` constructor signature:
+```typescript
+constructor(
+  private newDomain: string | undefined,
+  private oldDomain: string | undefined,
+  private newSessionScope: string | undefined,
+  private oldSessionScope: string | undefined,
+  private newPhase: string | undefined,
+  private oldPhase: string | undefined,
+  private newAutonomousEnabled: boolean,
+  private oldAutonomousEnabled: boolean
+)
+```
+
+Note: `EventStormingPhase` type does not need to be imported — the existing `isPhaseActive()` method already takes `phase: string` and the command constructor uses `string | undefined`.
+
+### Step 2: Add click and keyboard handlers to the template
+
+Update the `.step` div in `board.component.html` (line 170) to add:
+- `(click)="onPhaseClick(phase.value)"` — triggers phase change on click
+- `(keydown.enter)="onPhaseClick(phase.value)"` — keyboard activation via Enter
+- `(keydown.space)="$event.preventDefault(); onPhaseClick(phase.value)"` — keyboard activation via Space (must call `$event.preventDefault()` to suppress the browser's default page scroll on Space)
+- `tabindex="0"` — makes steps focusable
+- `role="button"` — communicates clickability to screen readers
+- `[attr.aria-current]="isPhaseActive(phase.value) ? 'step' : null"` — conveys which step is active (prefer `aria-current="step"` over `aria-pressed` because the steps are mutually exclusive, not toggleable)
+
+Also change the parent `<div class="stepper-content">` from `role="progressbar"` to `role="group"`. The ARIA `progressbar` role does not allow interactive child roles like `button`. `role="group"` is semantically correct for a set of related interactive elements.
+
+**Current template** (lines 167–177):
+```html
+<div class="stepper-content" role="progressbar" aria-label="Event Storming Phase">
+  @for (phase of phases; track phase.value; let i = $index) {
+    <div class="step" [class.active]="isPhaseActive(phase.value)">
+      <div class="step-circle">{{ i + 1 }}</div>
+      <span class="step-label">{{ phase.label }}</span>
+    </div>
+    @if (i < phases.length - 1) {
+      <div class="step-connector" [class.active]="isPhaseActive(phase.value)"></div>
+    }
+```
+
+**Updated template**:
+```html
+<div class="stepper-content" role="group" aria-label="Event Storming Phase">
+  @for (phase of phases; track phase.value; let i = $index) {
+    <div class="step" [class.active]="isPhaseActive(phase.value)"
+         (click)="onPhaseClick(phase.value)"
+         (keydown.enter)="onPhaseClick(phase.value)"
+         (keydown.space)="$event.preventDefault(); onPhaseClick(phase.value)"
+         tabindex="0"
+         role="button"
+         [attr.aria-current]="isPhaseActive(phase.value) ? 'step' : null">
+      <div class="step-circle">{{ i + 1 }}</div>
+      <span class="step-label">{{ phase.label }}</span>
+    </div>
+    @if (i < phases.length - 1) {
+      <div class="step-connector" [class.active]="isPhaseActive(phase.value)"></div>
+    }
+```
+
+### Step 3: Add focus-visible styles to SCSS
+
+Add a `:focus-visible` style to the `.step` rule in `board.component.scss` (within the `.phase-stepper-container` block). This provides a visible focus indicator for keyboard navigation without showing it on mouse click.
+
+**Code example** — add inside the existing `.step { ... }` block:
+```scss
+&:focus-visible {
+  outline: 1px solid var(--sys-primary);
+  outline-offset: 2px;
+}
+```
+
+**Reference**: The `.step` already has `cursor: pointer` and `&:hover` / `&.active` styles in `board.component.scss`. The focus-visible rule should sit alongside these.
+
+## Verification Criteria
+
+- [ ] `cd src/eventstormingboard.client && npx ng build` passes with no errors
+- [ ] Clicking a non-active phase step in the UI changes the active phase (`.active` class moves)
+- [ ] Clicking the already-active phase does nothing — verify by checking the browser DevTools Network/Console tab for absence of a duplicate `BoardContextUpdated` SignalR message
+- [ ] Phase change broadcasts to other connected clients — verify by opening two browser tabs on the same board and clicking a phase in one tab; the other tab should update
+- [ ] Undo (Ctrl+Z) after clicking a phase step reverts to the previous phase, confirming FR-4 command stack integration
+- [ ] Steps are keyboard-focusable (Tab) and activatable (Enter/Space). Pressing Space does **not** scroll the page
+- [ ] No backend changes — `dotnet build src/EventStormingBoard.Server/EventStormingBoard.Server.csproj` still passes
+- [ ] `dotnet test tests/EventStormingBoard.Server.Tests/` still passes (no regressions)

--- a/.agent-context/tasks/click-phase-stepper/plan.md
+++ b/.agent-context/tasks/click-phase-stepper/plan.md
@@ -1,0 +1,34 @@
+# Plan: Clickable Phase Stepper
+
+**Objective**: Allow users to change the board's active workshop phase by clicking on a step in the phase stepper, broadcasting the change to all connected clients via SignalR.
+**Phases**: 1
+**Estimated complexity**: Low
+
+## Context
+
+The phase stepper in `board.component.html` (lines 165–181) currently renders five workshop phases as a read-only progress indicator. Users must open the board context settings dialog to change phases. This task adds click-to-navigate behaviour directly on each step, using the existing `UpdateBoardContextCommand` and SignalR broadcast pipeline — no backend changes needed.
+
+## Phase Summary
+
+| Phase | Name | Description | Files Modified | Verification |
+|-------|------|-------------|----------------|--------------|
+| 1 | Clickable Phase Steps | Add click handler, keyboard a11y, and `onPhaseClick()` method to the phase stepper | `board.component.html`, `board.component.ts`, `board.component.scss` | `npm run build` passes; manual click test |
+
+## Dependencies
+
+None. All backend infrastructure (`BroadcastBoardContextUpdated`, `BoardContextUpdatedEvent`, `BoardEventPipeline`, `BoardStateService`) already exists and is tested.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Clicking sends redundant events for the already-active phase | Guard in `onPhaseClick()` — no-op when clicking the current phase (FR-5) |
+| ARIA role mismatch — current `role="progressbar"` doesn't semantically fit clickable steps | Change parent to `role="group"` and use `aria-current="step"` for active state (not `aria-pressed`, which implies toggle semantics) |
+| Space key scrolls page when step is focused | `$event.preventDefault()` in the `(keydown.space)` handler suppresses browser default scroll |
+
+## Spec Open-Question Resolutions
+
+The spec raised three open questions. These are resolved as follows for this implementation:
+- **Unrestricted navigation**: Users can jump to any phase freely. Restricting navigation (e.g., only forward) is out of scope per the spec.
+- **All participants can click**: No role-based gating. Any board participant can change the phase. Role restrictions are out of scope.
+- **Autonomous mode not gated**: Clicking a phase step is allowed even during autonomous AI sessions. Conflict avoidance is out of scope.

--- a/.agent-context/tasks/click-phase-stepper/progress.md
+++ b/.agent-context/tasks/click-phase-stepper/progress.md
@@ -10,7 +10,7 @@
 
 | Phase | Name | Started | Completed | Notes |
 |-------|------|---------|-----------|-------|
-| 1 | Clickable Phase Steps | 2026-04-12T19:04:40Z | | In progress |
+| 1 | Clickable Phase Steps | 2026-04-12T19:04:40Z | 2026-04-12T19:06:17Z | Completed |
 
 ## Pipeline Stages
 
@@ -20,7 +20,7 @@
 | Planning | 2026-04-12T18:49:47Z | 2026-04-12T18:54:35Z | Completed | 1 phase — frontend only |
 | Plan Review | 2026-04-12T18:54:35Z | 2026-04-12T19:03:57Z | Completed | 5 findings fixed: ARIA, Space key, undo/redo, line numbers |
 | Plan Approval | | | Skipped (--auto) | Auto mode |
-| Implementation | | | | |
+| Implementation | 2026-04-12T19:04:40Z | 2026-04-12T19:06:17Z | Completed | 1 phase completed |
 | Implementation Review | | | | |
 | Regression Testing | | | | |
 | Regression Fixes | | | | |

--- a/.agent-context/tasks/click-phase-stepper/progress.md
+++ b/.agent-context/tasks/click-phase-stepper/progress.md
@@ -1,0 +1,60 @@
+# Progress: Click Phase on Phase Stepper
+
+**Task**: Enable clicking on a phase in the phase stepper UI component
+**Started**: 2026-04-12T18:45:38Z
+**Status**: In Progress
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan.md](plan.md)
+
+## Phase Status
+
+| Phase | Name | Started | Completed | Notes |
+|-------|------|---------|-----------|-------|
+| 1 | Clickable Phase Steps | | | |
+
+## Pipeline Stages
+
+| Stage | Started | Completed | Status | Notes |
+|-------|---------|-----------|--------|-------|
+| Specification | 2026-04-12T18:45:38Z | 2026-04-12T18:49:47Z | Completed | Refine enabled; Q&A unavailable — spec drafted without refinement |
+| Planning | 2026-04-12T18:49:47Z | 2026-04-12T18:54:35Z | Completed | 1 phase — frontend only |
+| Plan Review | 2026-04-12T18:54:35Z | 2026-04-12T19:03:57Z | Completed | 5 findings fixed: ARIA, Space key, undo/redo, line numbers |
+| Plan Approval | | | Skipped (--auto) | Auto mode |
+| Implementation | | | | |
+| Implementation Review | | | | |
+| Regression Testing | | | | |
+| Regression Fixes | | | | |
+| Regression Re-verify | | | | |
+| Knowledge Update | | | | |
+
+## Issues Log
+
+| Timestamp | Phase | Severity | Description | Resolution |
+|-----------|-------|----------|-------------|------------|
+
+## Knowledge Updates
+
+| File | Action | Summary |
+|------|--------|---------|
+
+## GitHub Tracking
+
+| Key | Value |
+|-----|-------|
+| Tracking Issue | #35 |
+| Issue Node ID | 4249469945 |
+| Branch | task/click-phase-stepper |
+| PR | — |
+
+### Phase Sub-Issues
+
+| Phase | Name | Issue # | Node ID |
+|-------|------|---------|---------|  
+| 1 | Clickable Phase Steps | #36 | 4249498374 |
+
+### Regression Sub-Issue
+
+| Key | Value |
+|-----|-------|
+| Issue # | — |
+| Node ID | — |

--- a/.agent-context/tasks/click-phase-stepper/progress.md
+++ b/.agent-context/tasks/click-phase-stepper/progress.md
@@ -21,8 +21,8 @@
 | Plan Review | 2026-04-12T18:54:35Z | 2026-04-12T19:03:57Z | Completed | 5 findings fixed: ARIA, Space key, undo/redo, line numbers |
 | Plan Approval | | | Skipped (--auto) | Auto mode |
 | Implementation | 2026-04-12T19:04:40Z | 2026-04-12T19:06:17Z | Completed | 1 phase completed |
-| Implementation Review | | | | |
-| Regression Testing | | | | |
+| Implementation Review | 2026-04-12T19:06:17Z | 2026-04-12T19:14:18Z | Passed | 1 MAJOR + 3 MINOR fixed; 2 MAJOR deferred (pre-existing) |
+| Regression Testing | 2026-04-12T19:14:18Z | 2026-04-12T19:23:40Z | Passed | 8/8 journeys passed |
 | Regression Fixes | | | | |
 | Regression Re-verify | | | | |
 | Knowledge Update | | | | |
@@ -44,7 +44,7 @@
 | Tracking Issue | #35 |
 | Issue Node ID | 4249469945 |
 | Branch | task/click-phase-stepper |
-| PR | — |
+| PR | #38 |
 
 ### Phase Sub-Issues
 
@@ -56,5 +56,5 @@
 
 | Key | Value |
 |-----|-------|
-| Issue # | — |
-| Node ID | — |
+| Issue # | #37 |
+| Node ID | 4249578019 |

--- a/.agent-context/tasks/click-phase-stepper/progress.md
+++ b/.agent-context/tasks/click-phase-stepper/progress.md
@@ -10,7 +10,7 @@
 
 | Phase | Name | Started | Completed | Notes |
 |-------|------|---------|-----------|-------|
-| 1 | Clickable Phase Steps | | | |
+| 1 | Clickable Phase Steps | 2026-04-12T19:04:40Z | | In progress |
 
 ## Pipeline Stages
 

--- a/.agent-context/tasks/click-phase-stepper/spec.md
+++ b/.agent-context/tasks/click-phase-stepper/spec.md
@@ -1,0 +1,43 @@
+# Specification: Clickable Phase Stepper
+
+## Overview
+The board's phase stepper UI currently displays the five Event Storming workshop phases (Set the Context → Identify Events → Add Commands & Policies → Define Aggregates → Break It Down) as a read-only progress indicator. Users can only change phases through the board context settings dialog or via AI agents. This feature adds click-to-navigate behaviour to each step in the stepper, allowing users to change the active workshop phase directly by clicking on it.
+
+## Goals
+- Allow users to change the board's active phase by clicking on a step in the phase stepper
+- Reduce friction in phase navigation — clicking a step should be a single-action shortcut instead of opening the settings dialog
+- Broadcast the phase change to all connected clients in real time via SignalR
+
+## User Stories
+- As a workshop facilitator, I want to click on a phase in the stepper so that I can quickly jump to any phase without opening the settings dialog
+- As a board participant, I want to see the active phase update in real time when another user clicks a phase step
+
+## Functional Requirements
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | Each step in the phase stepper must be clickable | Must |
+| FR-2 | Clicking a step sets that phase as the active board phase | Must |
+| FR-3 | The phase change must broadcast to all connected clients via the existing `BoardContextUpdated` SignalR event | Must |
+| FR-4 | The phase change must go through the existing `UpdateBoardContextCommand` and event pipeline so it supports undo/redo | Must |
+| FR-5 | Clicking the currently active phase should be a no-op (no duplicate event broadcast) | Must |
+| FR-6 | The clicked step should visually update to the active state immediately for the clicking user | Must |
+
+## Non-Functional Requirements
+- The click interaction should feel instant — no perceptible delay before the active step updates
+- Accessibility: steps should be focusable and activatable via keyboard (Enter/Space)
+
+## Constraints & Assumptions
+- The existing `UpdateBoardContextCommand` already supports phase changes alongside domain, session scope, and autonomous mode — the click handler should only change the phase, preserving all other board context values
+- The existing `BoardContextUpdatedEvent` and SignalR hub method (`BroadcastBoardContextUpdated`) handle propagation to other clients — no new backend endpoints are needed
+- The phase stepper already has `cursor: pointer` CSS and `:hover` styles, so the visual affordance for clickability is partially in place
+
+## Out of Scope
+- Adding confirmation dialogs or guards before phase changes
+- Restricting which phases can be navigated to (e.g., preventing skipping ahead)
+- Changing the visual design of the stepper beyond what is needed for click interaction
+- Backend validation of phase transitions
+
+## Open Questions
+- Should users be able to jump to any phase freely, or should navigation be restricted (e.g., only move forward, or only to already-visited phases)?
+- Should clicking a phase step be available to all board participants, or only certain roles (e.g., board owner/facilitator)?
+- When an AI autonomous session is active, should manual phase clicking be disabled to avoid conflicts with agent-driven phase progression?

--- a/src/eventstormingboard.client/src/app/board/board.component.html
+++ b/src/eventstormingboard.client/src/app/board/board.component.html
@@ -173,7 +173,9 @@
              (keydown.space)="$event.preventDefault(); onPhaseClick(phase.value)"
              tabindex="0"
              role="button"
-             [attr.aria-current]="isPhaseActive(phase.value) ? 'step' : null">
+             [attr.aria-label]="'Go to phase: ' + phase.label"
+             [attr.aria-current]="isPhaseActive(phase.value) ? 'step' : null"
+             [attr.aria-disabled]="isPhaseActive(phase.value) ? 'true' : null">
           <div class="step-circle">{{ i + 1 }}</div>
           <span class="step-label">{{ phase.label }}</span>
         </div>

--- a/src/eventstormingboard.client/src/app/board/board.component.html
+++ b/src/eventstormingboard.client/src/app/board/board.component.html
@@ -165,9 +165,15 @@
 
 <div class="phase-stepper-wrapper">
   <div class="phase-stepper-container floating">
-    <div class="stepper-content" role="progressbar" aria-label="Event Storming Phase">
+    <div class="stepper-content" role="group" aria-label="Event Storming Phase">
       @for (phase of phases; track phase.value; let i = $index) {
-        <div class="step" [class.active]="isPhaseActive(phase.value)">
+        <div class="step" [class.active]="isPhaseActive(phase.value)"
+             (click)="onPhaseClick(phase.value)"
+             (keydown.enter)="onPhaseClick(phase.value)"
+             (keydown.space)="$event.preventDefault(); onPhaseClick(phase.value)"
+             tabindex="0"
+             role="button"
+             [attr.aria-current]="isPhaseActive(phase.value) ? 'step' : null">
           <div class="step-circle">{{ i + 1 }}</div>
           <span class="step-label">{{ phase.label }}</span>
         </div>

--- a/src/eventstormingboard.client/src/app/board/board.component.scss
+++ b/src/eventstormingboard.client/src/app/board/board.component.scss
@@ -461,6 +461,12 @@
     &:focus-visible {
       outline: 1px solid var(--sys-primary);
       outline-offset: 2px;
+
+      .step-label {
+        max-width: 150px;
+        opacity: 1;
+        margin-left: var(--space-3);
+      }
     }
 
     &.active {

--- a/src/eventstormingboard.client/src/app/board/board.component.scss
+++ b/src/eventstormingboard.client/src/app/board/board.component.scss
@@ -458,6 +458,11 @@
     transition: all var(--duration-slow) var(--ease-sharp);
     cursor: pointer;
 
+    &:focus-visible {
+      outline: 1px solid var(--sys-primary);
+      outline-offset: 2px;
+    }
+
     &.active {
       opacity: 1;
 

--- a/src/eventstormingboard.client/src/app/board/board.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board.component.ts
@@ -101,6 +101,25 @@ export class BoardComponent implements OnInit, OnDestroy {
     return this.canvasService.boardState.phase === phase;
   }
 
+  public onPhaseClick(phase: string): void {
+    if (this.isPhaseActive(phase)) {
+      return;
+    }
+
+    const command = new UpdateBoardContextCommand(
+      this.canvasService.boardState.domain,
+      this.canvasService.boardState.domain,
+      this.canvasService.boardState.sessionScope,
+      this.canvasService.boardState.sessionScope,
+      phase,
+      this.canvasService.boardState.phase,
+      this.canvasService.boardState.autonomousEnabled,
+      this.canvasService.boardState.autonomousEnabled
+    );
+
+    this.canvasService.executeCommand(command);
+  }
+
   public exportBoardAsJSON(): void {
     const boardState = {
       boardName: this.canvasService.boardState.name,

--- a/src/eventstormingboard.client/src/app/board/board.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board.component.ts
@@ -21,7 +21,7 @@ import { AiChatPanelComponent } from './ai-chat-panel/ai-chat-panel.component';
 import { BoardContextModalComponent, BoardContextData } from './board-context-modal/board-context-modal.component';
 import { AgentConfigModalComponent, AgentConfigModalData } from './agent-config-modal/agent-config-modal.component';
 import { AgentConfiguration } from '../_shared/models/agent-configuration.model';
-import { EVENT_STORMING_PHASES } from '../_shared/models/board.model';
+import { EVENT_STORMING_PHASES, EventStormingPhase } from '../_shared/models/board.model';
 import { UserService } from '../_shared/services/user.service';
 import { Connection } from '../_shared/models/connection.model';
 import { BoundedContext } from '../_shared/models/bounded-context.model';
@@ -97,11 +97,11 @@ export class BoardComponent implements OnInit, OnDestroy {
     });
   }
 
-  public isPhaseActive(phase: string): boolean {
+  public isPhaseActive(phase: EventStormingPhase): boolean {
     return this.canvasService.boardState.phase === phase;
   }
 
-  public onPhaseClick(phase: string): void {
+  public onPhaseClick(phase: EventStormingPhase): void {
     if (this.isPhaseActive(phase)) {
       return;
     }


### PR DESCRIPTION
Closes #35

Add click handlers, keyboard accessibility, and focus styles to the phase stepper component so users can navigate between phases by clicking on phase steps.