### PR TITLE
Click User Icon to Navigate to Cursor

### DIFF
--- a/.agent-context/knowledge/user-journeys.md
+++ b/.agent-context/knowledge/user-journeys.md
@@ -144,7 +144,7 @@ dialog "Select a Board"
 | Export as Image | `image` | Icon button with `image` icon | Downloads canvas as PNG |
 | Export as JSON | `download` | Icon button with `download` icon | Downloads board JSON |
 | Import from JSON | `upload` | Icon button with `upload` icon | File input trigger |
-| User circles | — | Circular elements with initial letters | Shows connected users |
+| User circles | — | Circular elements with initial letters | Shows connected users; clickable to pan to that user's cursor |
 | Agent circles | — | Circular elements with bot badges | Shows active AI agents |
 
 #### Agent Avatar Icons
@@ -539,6 +539,48 @@ These steps are for **manual testing only** — do not execute in automated runs
 | 3 | Click outside popover | `playwright-cli eval "document.querySelector('.settings-menu-backdrop').click()"` | Popover closes |
 
 **Note**: The backdrop must be clicked using a JS eval with CSS selector (`.settings-menu-backdrop`), not a snapshot ref. The theme indicator shows icon `dark_mode` + "Dark" or `light_mode` + "Light" depending on current theme.
+
+---
+
+## Journey 11: Navigate to User Cursor
+
+**Precondition**: On board page with at least one other connected user who has a tracked cursor position
+
+Clicking another user's avatar circle in the top bar smoothly pans the canvas to that user's cursor position and shows a pulse highlight effect on the target cursor.
+
+### Steps
+
+| # | Action | Command | Expected Result |
+|---|--------|---------|-----------------|
+| 1 | Click a remote user's avatar circle in the top bar | `playwright-cli click <ref of user circle>` | Canvas smoothly animates to centre on that user's cursor position; cyan pulse rings appear on the target cursor |
+| 2 | Verify canvas centred | `playwright-cli snapshot` | Canvas viewport is centred on the target user's cursor location |
+
+### Behaviour Details
+
+| Aspect | Detail |
+|--------|--------|
+| **Animation** | 400ms easeOutCubic pan animation via `requestAnimationFrame` |
+| **Highlight effect** | Two concentric cyan pulse rings (`rgba(0, 240, 255)`) expanding outward for 1500ms |
+| **Local user click** | Clicking your own avatar does nothing (no-op) |
+| **No cursor available** | If the target user has no tracked cursor position, a snackbar appears: "No cursor position available" (2s, top-centre) |
+| **Cursor styling** | User avatar circles show `cursor: pointer`; local user circle shows `cursor: default` |
+
+### Data Flow
+
+1. `BoardComponent.navigateToUserCursor(user)` looks up cursor in `BoardCanvasService.remoteCursors` map
+2. Emits `{ x, y, highlightConnectionId }` via `BoardCanvasService.navigateToCoordinate$` Subject
+3. `BoardCanvasComponent` subscribes, calls `animatePanTo()` to smoothly update `originX`/`originY`
+4. On animation complete, sets `highlightedCursorConnectionId` + `highlightStartTime` to trigger pulse rendering
+5. `drawRemoteCursors()` renders expanding/fading cyan rings around the highlighted cursor for 1500ms
+
+### Key Files
+
+| File | Change |
+|------|--------|
+| `src/eventstormingboard.client/src/app/board/board.component.ts` | `navigateToUserCursor()` method, avatar click handler |
+| `src/eventstormingboard.client/src/app/board/board.component.html` | `(click)="navigateToUserCursor(user)"` on user circles |
+| `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts` | `navigateToCoordinate$` Subject, `highlightedCursorConnectionId`, `highlightStartTime` |
+| `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts` | `animatePanTo()`, pulse ring rendering in `drawRemoteCursors()` |
 
 ---
 

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/phase-1-click-to-navigate.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/phase-1-click-to-navigate.md
@@ -1,0 +1,250 @@
+# Phase 1: Click-to-Navigate with Animated Pan
+
+**Objective**: Add click handlers on user avatar circles in the header that smoothly animate the canvas to the clicked user's cursor position, with feedback when no cursor is available and no-op for the local user.
+**Files to modify** (6 files):
+- `src/eventstormingboard.client/src/app/_shared/services/boards-signalr.service.ts` — expose `connectionId` getter
+- `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts` — add `navigateToCoordinate$` Subject and `highlightedCursorConnectionId` state
+- `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts` — subscribe to navigate Subject, implement animated pan, cancel RAF on destroy
+- `src/eventstormingboard.client/src/app/board/board.component.ts` — add `navigateToUserCursor()` method, inject `MatSnackBar`, add `localConnectionId` getter
+- `src/eventstormingboard.client/src/app/board/board.component.html` — add `(click)` handler on user circles
+- `src/eventstormingboard.client/src/app/board/board.component.scss` — style user circles as clickable
+
+## Context
+
+The minimap already implements instant pan by setting `originX`/`originY` directly. This phase adds the same coordinate math but with `requestAnimationFrame`-based easing. The `BoardsSignalRService` wraps a SignalR `HubConnection` whose `connectionId` property uniquely identifies the local client — we expose this to distinguish the local user from remote users in the `connectedUsers` list.
+
+## Knowledge, Instructions & Skills
+
+- `.github/instructions/angular.instructions.md` — Angular 21 conventions: `inject()`, signals, `takeUntilDestroyed()`, standalone component imports
+- `.github/skills/frontend-design/SKILL.md` — Kinetic Ionization design tokens for cursor styling (if adjusting user circle hover states)
+- `.agent-context/knowledge/architecture-principles.md` — Canvas service architecture, Subject-based communication
+
+## Implementation Steps
+
+### Step 1: Expose `connectionId` from `BoardsSignalRService`
+
+Add a public getter that returns the SignalR `HubConnection.connectionId`. This is `null` before the connection is established and a unique string after.
+
+**File**: `src/eventstormingboard.client/src/app/_shared/services/boards-signalr.service.ts`
+
+Add after the existing `autonomousStatuses` field (around line 82):
+
+```typescript
+public get connectionId(): string | null | undefined {
+  return this.hubConnection?.connectionId;
+}
+```
+
+**Reference**: The `hubConnection` is already a private field on this service (line ~55). The `connectionId` property is part of the `@microsoft/signalr` `HubConnection` API.
+
+### Step 2: Add navigation Subject and highlight state to `BoardCanvasService`
+
+Add a Subject that `BoardCanvasComponent` will subscribe to for animated pan requests, plus state for the cursor highlight (used in Phase 2, but added now to keep the interface clean).
+
+**File**: `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts`
+
+Add after the existing `canvasImageDownloaded$` field:
+
+```typescript
+public navigateToCoordinate$ = new Subject<{ x: number; y: number; highlightConnectionId?: string }>();
+public highlightedCursorConnectionId: string | null = null;
+public highlightStartTime = 0;
+```
+
+### Step 3: Implement animated pan in `BoardCanvasComponent`
+
+Subscribe to `navigateToCoordinate$` and animate `originX`/`originY` using `requestAnimationFrame` with ease-out-cubic easing over 400ms. Cancel any in-flight animation when a new one starts.
+
+**File**: `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts`
+
+Add private fields to track the active animation and component lifecycle:
+
+```typescript
+private panAnimationId: number | null = null;
+private destroyed = false;
+```
+
+Add subscription in `ngOnInit()` (after existing subscriptions):
+
+```typescript
+this.canvasService.navigateToCoordinate$
+  .pipe(takeUntilDestroyed(this.destroyRef))
+  .subscribe(target => this.animatePanTo(target.x, target.y, target.highlightConnectionId));
+```
+
+Add destroy cleanup in `ngOnDestroy()` (or add `OnDestroy` implementation if not present):
+
+```typescript
+ngOnDestroy(): void {
+  this.destroyed = true;
+  if (this.panAnimationId !== null) {
+    cancelAnimationFrame(this.panAnimationId);
+    this.panAnimationId = null;
+  }
+}
+```
+
+Add the animated pan method:
+
+```typescript
+private animatePanTo(worldX: number, worldY: number, highlightConnectionId?: string): void {
+  // Cancel any in-flight animation
+  if (this.panAnimationId !== null) {
+    cancelAnimationFrame(this.panAnimationId);
+    this.panAnimationId = null;
+  }
+
+  const canvasEl = this.canvas().nativeElement;
+  const targetOriginX = -worldX * this.canvasService.scale + canvasEl.width / 2;
+  const targetOriginY = -worldY * this.canvasService.scale + canvasEl.height / 2;
+
+  const startOriginX = this.canvasService.originX;
+  const startOriginY = this.canvasService.originY;
+  const duration = 400;
+  const startTime = performance.now();
+
+  const animate = (now: number) => {
+    // Guard against firing after component destroy
+    if (this.destroyed) {
+      this.panAnimationId = null;
+      return;
+    }
+
+    const elapsed = now - startTime;
+    const t = Math.min(elapsed / duration, 1);
+    const eased = t < 1 ? 1 - Math.pow(1 - t, 3) : 1; // easeOutCubic
+
+    this.canvasService.originX = startOriginX + (targetOriginX - startOriginX) * eased;
+    this.canvasService.originY = startOriginY + (targetOriginY - startOriginY) * eased;
+
+    this.drawCanvasFrame();
+
+    if (t < 1) {
+      this.panAnimationId = requestAnimationFrame(animate);
+    } else {
+      this.panAnimationId = null;
+      // FR-5: Set highlight AFTER animation completes so the full pulse effect
+      // plays once the target cursor is centred on screen
+      if (highlightConnectionId) {
+        this.canvasService.highlightedCursorConnectionId = highlightConnectionId;
+        this.canvasService.highlightStartTime = Date.now();
+        this.drawCanvas(); // Kick off the highlight redraw loop
+      }
+    }
+  };
+
+  this.panAnimationId = requestAnimationFrame(animate);
+}
+```
+
+**Reference**: The coordinate math (`-worldX * scale + canvasEl.width / 2`) is identical to `onMinimapClick()` at line ~104 of `board-canvas.component.ts`. The easing curve matches the Kinetic Ionization spec: `cubic-bezier(0.4, 0, 0.2, 1)` approximated as easeOutCubic.
+
+**Note**: The animation callback calls `drawCanvasFrame()` directly (not `drawCanvas()`) to avoid double-scheduling through the `rafPending` indirection, which would cause a 1-frame rendering lag. The final frame after completion calls `drawCanvas()` to kick off the highlight redraw loop via Phase 2.
+
+### Step 4: Add `navigateToUserCursor()` to `BoardComponent`
+
+This method looks up the cursor position by `connectionId`, triggers animated pan or shows a snackbar.
+
+**File**: `src/eventstormingboard.client/src/app/board/board.component.ts`
+
+Add `MatSnackBar` import and injection:
+
+```typescript
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+```
+
+Add `MatSnackBarModule` to the component's `imports` array.
+
+Inject the snackbar and SignalR service:
+
+```typescript
+private snackBar = inject(MatSnackBar);
+```
+
+Add a public getter for the local connection ID (used in template for local-user styling):
+
+```typescript
+get localConnectionId(): string | null | undefined {
+  return this.boardsHub.connectionId;
+}
+```
+
+Add the navigation method:
+
+```typescript
+public navigateToUserCursor(user: BoardUser): void {
+  // FR-6: Skip local user. Also skip if connectionId isn't established yet
+  // (prevents false navigation attempt for own avatar before SignalR connects)
+  const localId = this.boardsHub.connectionId;
+  if (!localId || user.connectionId === localId) {
+    return;
+  }
+
+  const cursor = this.canvasService.remoteCursors.get(user.connectionId);
+  if (!cursor) {
+    // FR-4: No cursor position available.
+    // Spec says "tooltip" but a click-triggered tooltip is poor UX (matTooltip is hover-only).
+    // A snackbar provides clear, transient click feedback — deliberate spec deviation.
+    this.snackBar.open('No cursor position available', '', {
+      duration: 2000,
+      horizontalPosition: 'center',
+      verticalPosition: 'top'
+    });
+    return;
+  }
+
+  // FR-1 & FR-2: Animated pan to cursor position
+  this.canvasService.navigateToCoordinate$.next({
+    x: cursor.x,
+    y: cursor.y,
+    highlightConnectionId: cursor.connectionId
+  });
+}
+```
+
+### Step 5: Add click handler to user avatar template
+
+**File**: `src/eventstormingboard.client/src/app/board/board.component.html`
+
+Update the user-circle `<div>` to add a click handler. Use the `localConnectionId` getter (added in Step 4) for template access — `boardsHub` remains private:
+
+```html
+<div
+  class="user-circle"
+  [class.local-user]="user.connectionId === localConnectionId"
+  [style.background-color]="user.getColour()"
+  [matTooltip]="user.userName"
+  (click)="navigateToUserCursor(user)">
+  {{ user.userName.charAt(0).toUpperCase() }}
+</div>
+```
+
+Then in template: `[class.local-user]="user.connectionId === localConnectionId"`
+
+### Step 6: Style user circles as clickable
+
+**File**: `src/eventstormingboard.client/src/app/board/board.component.scss`
+
+Update the `.user-circle` styles:
+
+```scss
+.user-circle {
+  // ... existing styles ...
+  cursor: pointer;
+
+  &.local-user {
+    cursor: default;
+  }
+}
+```
+
+## Verification Criteria
+
+- [ ] `cd src/eventstormingboard.client && npm run build` passes with no errors
+- [ ] Clicking a remote user's avatar in the header smoothly pans the canvas (animated over ~400ms) to center on their cursor
+- [ ] The zoom level does not change during navigation
+- [ ] Clicking a user with no known cursor position shows "No cursor position available" snackbar
+- [ ] Clicking the local user's own avatar does nothing (no pan, no snackbar)
+- [ ] User circles appear clickable (pointer cursor) for remote users, default cursor for local user
+- [ ] Rapid double-click on a user avatar doesn't cause visual glitches (animation cancellation works)
+- [ ] User avatars remain clickable in both collapsed (≤5) and expanded (hover) states

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/phase-2-cursor-highlight.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/phase-2-cursor-highlight.md
@@ -1,0 +1,96 @@
+# Phase 2: Cursor Highlight Pulse Effect
+
+**Objective**: After the pan animation completes, draw an animated pulse ring around the target user's cursor so it stands out visually. The effect fades over ~1.5 seconds.
+**Files to modify**:
+- `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts` — modify `drawRemoteCursors()` to render pulse ring, add continuous redraw during highlight
+
+## Context
+
+Phase 1 sets `highlightedCursorConnectionId` and `highlightStartTime` on `BoardCanvasService` **after the pan animation completes** (in the RAF completion branch). This phase reads that state during the canvas draw loop to render a pulse effect. The existing `drawCanvas()` method uses `requestAnimationFrame` batching via `rafPending` — the highlight triggers repeated redraws until the effect completes.
+
+The pulse uses the design system's `primaryContainer` color (`#00f0ff` in dark mode, `#00838f` in light mode) — the same cyan used for selection indicators and grid lines, matching the Kinetic Ionization palette.
+
+## Knowledge, Instructions & Skills
+
+- `.github/instructions/angular.instructions.md` — Component patterns
+- `.github/skills/frontend-design/SKILL.md` — Kinetic Ionization animation specs: sharp easing, 300ms in / 200ms out conventions; primary/primaryContainer color tokens
+- `.agent-context/knowledge/architecture-principles.md` — Canvas rendering pipeline
+
+## Implementation Steps
+
+### Step 1: Modify `drawRemoteCursors()` to render highlight pulse
+
+**File**: `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts`
+
+At the end of the per-cursor drawing loop in `drawRemoteCursors()`, after `this.ctx.restore()`, add a highlight ring check:
+
+```typescript
+// After the existing ctx.restore() for each cursor:
+if (cursor.connectionId === this.canvasService.highlightedCursorConnectionId) {
+  const elapsed = Date.now() - this.canvasService.highlightStartTime;
+  const highlightDuration = 1500; // 1.5 seconds
+
+  if (elapsed < highlightDuration) {
+    const progress = elapsed / highlightDuration;
+    const radius = 20 + progress * 30; // Expand from 20px to 50px
+    const opacity = (1 - progress) * 0.6; // Fade from 0.6 to 0
+
+    this.ctx.save();
+    this.ctx.beginPath();
+    this.ctx.arc(cursor.x, cursor.y, radius, 0, Math.PI * 2);
+    this.ctx.strokeStyle = `rgba(0, 240, 255, ${opacity})`;
+    this.ctx.lineWidth = 2;
+    this.ctx.stroke();
+
+    // Second ring (offset for depth)
+    const radius2 = 10 + progress * 20;
+    const opacity2 = (1 - progress) * 0.3;
+    this.ctx.beginPath();
+    this.ctx.arc(cursor.x, cursor.y, radius2, 0, Math.PI * 2);
+    this.ctx.strokeStyle = `rgba(0, 240, 255, ${opacity2})`;
+    this.ctx.lineWidth = 1.5;
+    this.ctx.stroke();
+
+    this.ctx.restore();
+  } else {
+    // Clear highlight after duration
+    this.canvasService.highlightedCursorConnectionId = null;
+  }
+}
+```
+
+**Note on color**: Using `rgba(0, 240, 255, ...)` directly rather than the theme token because the canvas API needs rgba strings with dynamic opacity. `#00f0ff` is the dark-mode `primaryContainer` token value. For proper theme support, a helper could extract the RGB, but the cyan pulse is intentionally vivid in both themes.
+
+### Step 2: Add continuous redraw during highlight animation
+
+The highlight needs to redraw every frame during the 1.5s animation. Add a check in `drawCanvasFrame()` to schedule another frame if a highlight is active, with an elapsed-time safety guard to prevent permanent RAF churn if the target cursor is pruned from the `remoteCursors` map before the highlight drawing branch clears the state.
+
+**File**: `src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts`
+
+At the end of `drawCanvasFrame()` (after `this.drawMinimap()`), add:
+
+```typescript
+// Continue redrawing while cursor highlight is active
+if (this.canvasService.highlightedCursorConnectionId) {
+  const highlightElapsed = Date.now() - this.canvasService.highlightStartTime;
+  if (highlightElapsed < 1600) { // slightly over 1500ms duration to ensure final clear frame renders
+    this.drawCanvas();
+  } else {
+    // Safety expiry: clear highlight if the per-cursor drawing branch didn't clear it
+    // (e.g. cursor was pruned from remoteCursors while highlight was active)
+    this.canvasService.highlightedCursorConnectionId = null;
+  }
+}
+```
+
+This leverages the existing `rafPending` batching in `drawCanvas()` — it won't cause double-renders, it just ensures the next frame is scheduled. The elapsed-time guard prevents an unbounded redraw loop if the highlighted cursor disappears from the `remoteCursors` map (stale timer prune or user disconnect).
+
+## Verification Criteria
+
+- [ ] `cd src/eventstormingboard.client && npm run build` passes with no errors
+- [ ] After navigating to a user's cursor, a cyan pulse ring expands outward from the cursor position
+- [ ] The pulse ring fades from visible to transparent over approximately 1.5 seconds
+- [ ] After the pulse completes, no extra redraws occur (check that `highlightedCursorConnectionId` is cleared to `null`)
+- [ ] The pulse effect does not affect the cursor's normal appearance (pointer + label remain unchanged)
+- [ ] Multiple sequential navigations correctly show the pulse on each new target (previous highlight is replaced)
+- [ ] If the target cursor is pruned (user disconnects) during the highlight, the redraw loop terminates cleanly within ~1.6s

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/plan.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/plan.md
@@ -1,0 +1,44 @@
+# Plan: Click User Icon to Navigate to Their Cursor
+
+**Objective**: Enable clicking a user's avatar in the header to smoothly pan the board canvas to that user's cursor position, with visual feedback for missing cursors and a highlight effect on arrival.
+**Phases**: 2
+**Estimated complexity**: Low
+
+## Context
+
+StormSpace's board header displays connected users as avatar circles. Remote cursor positions are already tracked in `BoardCanvasService.remoteCursors` (a `Map<string, RemoteCursorState>` keyed by `connectionId`). The minimap already implements click-to-pan by setting `originX`/`originY` on the canvas service. This feature extends those existing patterns with animated panning, local-user detection, and a post-navigation cursor highlight.
+
+## Approach
+
+Single clear approach — extend existing patterns:
+1. Expose `hubConnection.connectionId` from `BoardsSignalRService` to identify the local user
+2. Add a `navigateToCoordinate$` Subject on `BoardCanvasService` (follows existing `canvasUpdated$` / `canvasImageDownloaded$` Subject pattern)
+3. `BoardCanvasComponent` subscribes and runs `requestAnimationFrame`-based animated pan (mirrors `onMinimapClick` coordinate math)
+4. `BoardComponent` adds `navigateToUserCursor(user)` handler — looks up cursor, triggers navigation or shows snackbar
+5. `drawRemoteCursors()` adds pulse ring rendering for the highlighted cursor
+
+No alternative approaches considered — this is a direct extension of proven canvas patterns.
+
+## Phase Summary
+
+| Phase | Name | Description | Files Modified | Verification |
+|-------|------|-------------|----------------|--------------|
+| 1 | Click-to-Navigate with Animated Pan | Add click handler on user avatars, animated pan to cursor position, MatSnackBar feedback for unknown cursors, local user skip | 6 files | `npm run build` passes; clicking remote user avatar pans canvas smoothly; clicking local user does nothing; clicking user with no cursor shows snackbar |
+| 2 | Cursor Highlight Pulse Effect | Draw animated pulse ring around target cursor after navigation completes | 2 files | `npm run build` passes; after pan animation, a cyan pulse ring expands and fades around the target cursor over ~1.5s |
+
+## Dependencies
+
+- `@angular/material` v21 is already installed — `MatSnackBarModule` available but not yet imported
+- No new packages needed
+- No backend changes needed
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `hubConnection.connectionId` may be `null` before connection establishes | Check for `null` before comparing — if null, treat as remote user (allows navigation attempt) |
+| Cursor pruned (stale >15s) before user clicks avatar | Show "No cursor position available" snackbar — this is expected behavior per spec |
+| Rapid repeated clicks could queue multiple animations | Cancel any in-flight animation before starting a new one (use animation ID tracking) |
+| `requestAnimationFrame` loop for highlight could conflict with existing `drawCanvas` RAF batching | The highlight triggers `drawCanvas()` which already batches via `rafPending` — no conflict. Elapsed-time guard prevents unbounded loop if target cursor is pruned |
+| Component destroyed during pan animation | `destroyed` guard in RAF callback + `cancelAnimationFrame` in `ngOnDestroy()` prevents post-destroy errors |
+| Local `connectionId` null before SignalR connects | Skip click handling entirely when `connectionId` is null — prevents false navigation for own avatar |

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
@@ -11,7 +11,7 @@
 | Phase | Name | Started | Completed | Notes |
 |-------|------|---------|-----------|-------|
 | 1 | Click-to-Navigate with Animated Pan | 2026-04-15T11:53:42Z | 2026-04-15T12:00:49Z | Build verified |
-| 2 | Cursor Highlight Pulse Effect | 2026-04-15T12:01:30Z | | |
+| 2 | Cursor Highlight Pulse Effect | 2026-04-15T12:01:30Z | 2026-04-15T12:04:57Z | Build verified |
 | 1 | Click-to-Navigate with Animated Pan | | | Core click handler, animated pan, snackbar feedback |
 | 2 | Cursor Highlight Pulse Effect | | | Animated pulse ring on target cursor |
 
@@ -23,8 +23,8 @@
 | Planning | 2026-04-15T11:45:00Z | 2026-04-15T11:52:00Z | Completed | 2 phases: click-to-navigate + cursor highlight |
 | Plan Review | 2026-04-15T11:40:15Z | 2026-04-15T11:51:52Z | Completed | 6 MAJOR + 3 MINOR findings fixed |
 | Plan Approval | | | Skipped (--auto) | |
-| Implementation | 2026-04-15T11:53:42Z | | In Progress | |
-| Implementation Review | | | | |
+| Implementation | 2026-04-15T11:53:42Z | 2026-04-15T12:04:57Z | Completed | Both phases done |
+| Implementation Review | 2026-04-15T12:35:00Z | 2026-04-15T12:38:15Z | Passed | 2 MAJOR + 1 MINOR fixed; 1 MAJOR + 2 MINOR deferred |
 | Regression Testing | | | | |
 | Regression Fixes | | | | |
 | Regression Re-verify | | | | |

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
@@ -2,7 +2,7 @@
 
 **Task**: Click on a user's icon in the header and be taken to where their cursor is on the board
 **Started**: 2026-04-15T11:23:15Z
-**Status**: In Progress
+**Status**: Completed
 **Spec**: [spec.md](spec.md)
 **Plan**: [plan.md](plan.md)
 
@@ -26,9 +26,9 @@
 | Implementation | 2026-04-15T11:53:42Z | 2026-04-15T12:04:57Z | Completed | Both phases done |
 | Implementation Review | 2026-04-15T12:35:00Z | 2026-04-15T12:38:15Z | Passed | 2 MAJOR + 1 MINOR fixed; 1 MAJOR + 2 MINOR deferred |
 | Regression Testing | 2026-04-15T12:39:00Z | 2026-04-15T12:49:53Z | Passed | 10/10 journeys passed; new feature validated |
-| Regression Fixes | | | | |
-| Regression Re-verify | | | | |
-| Knowledge Update | | | | |
+| Regression Fixes | | | Not Needed | |
+| Regression Re-verify | | | Skipped | |
+| Knowledge Update | 2026-04-15T12:50:00Z | 2026-04-15T12:54:43Z | Completed | user-journeys.md updated |
 
 ## Issues Log
 
@@ -39,6 +39,7 @@
 
 | File | Action | Summary |
 |------|--------|---------|
+| user-journeys.md | Updated | Added Journey 11 (Navigate to User Cursor); updated Top Bar Elements |
 
 ## GitHub Tracking
 

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
@@ -10,6 +10,7 @@
 
 | Phase | Name | Started | Completed | Notes |
 |-------|------|---------|-----------|-------|
+| 1 | Click-to-Navigate with Animated Pan | 2026-04-15T11:53:42Z | | |
 | 1 | Click-to-Navigate with Animated Pan | | | Core click handler, animated pan, snackbar feedback |
 | 2 | Cursor Highlight Pulse Effect | | | Animated pulse ring on target cursor |
 
@@ -21,7 +22,7 @@
 | Planning | 2026-04-15T11:45:00Z | 2026-04-15T11:52:00Z | Completed | 2 phases: click-to-navigate + cursor highlight |
 | Plan Review | 2026-04-15T11:40:15Z | 2026-04-15T11:51:52Z | Completed | 6 MAJOR + 3 MINOR findings fixed |
 | Plan Approval | | | Skipped (--auto) | |
-| Implementation | | | | |
+| Implementation | 2026-04-15T11:53:42Z | | In Progress | |
 | Implementation Review | | | | |
 | Regression Testing | | | | |
 | Regression Fixes | | | | |

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
@@ -25,7 +25,7 @@
 | Plan Approval | | | Skipped (--auto) | |
 | Implementation | 2026-04-15T11:53:42Z | 2026-04-15T12:04:57Z | Completed | Both phases done |
 | Implementation Review | 2026-04-15T12:35:00Z | 2026-04-15T12:38:15Z | Passed | 2 MAJOR + 1 MINOR fixed; 1 MAJOR + 2 MINOR deferred |
-| Regression Testing | | | | |
+| Regression Testing | 2026-04-15T12:39:00Z | 2026-04-15T12:49:53Z | Passed | 10/10 journeys passed; new feature validated |
 | Regression Fixes | | | | |
 | Regression Re-verify | | | | |
 | Knowledge Update | | | | |
@@ -47,7 +47,7 @@
 | Tracking Issue | #46 |
 | Issue Node ID | I_kwDONt0-ks6Pf6ep |
 | Branch | task/click-user-icon-navigate-cursor |
-| PR | — |
+| PR | #50 |
 
 ### Phase Sub-Issues
 
@@ -60,5 +60,5 @@
 
 | Key | Value |
 |-----|-------|
-| Issue # | — |
-| Node ID | — |
+| Issue # | #49 |
+| Node ID | I_kwDONt0-ks6PwbLd |

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
@@ -1,0 +1,62 @@
+# Progress: Click User Icon to Navigate to Cursor
+
+**Task**: Click on a user's icon in the header and be taken to where their cursor is on the board
+**Started**: 2026-04-15T11:23:15Z
+**Status**: In Progress
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan.md](plan.md)
+
+## Phase Status
+
+| Phase | Name | Started | Completed | Notes |
+|-------|------|---------|-----------|-------|
+| 1 | Click-to-Navigate with Animated Pan | | | Core click handler, animated pan, snackbar feedback |
+| 2 | Cursor Highlight Pulse Effect | | | Animated pulse ring on target cursor |
+
+## Pipeline Stages
+
+| Stage | Started | Completed | Status | Notes |
+|-------|---------|-----------|--------|-------|
+| Specification | 2026-04-15T11:23:15Z | 2026-04-15T11:31:26Z | Completed | Refined via Q&A (4 questions asked/answered) |
+| Planning | 2026-04-15T11:45:00Z | 2026-04-15T11:52:00Z | Completed | 2 phases: click-to-navigate + cursor highlight |
+| Plan Review | 2026-04-15T11:40:15Z | 2026-04-15T11:51:52Z | Completed | 6 MAJOR + 3 MINOR findings fixed |
+| Plan Approval | | | Skipped (--auto) | |
+| Implementation | | | | |
+| Implementation Review | | | | |
+| Regression Testing | | | | |
+| Regression Fixes | | | | |
+| Regression Re-verify | | | | |
+| Knowledge Update | | | | |
+
+## Issues Log
+
+| Timestamp | Phase | Severity | Description | Resolution |
+|-----------|-------|----------|-------------|------------|
+
+## Knowledge Updates
+
+| File | Action | Summary |
+|------|--------|---------|
+
+## GitHub Tracking
+
+| Key | Value |
+|-----|-------|
+| Tracking Issue | #46 |
+| Issue Node ID | I_kwDONt0-ks6Pf6ep |
+| Branch | task/click-user-icon-navigate-cursor |
+| PR | — |
+
+### Phase Sub-Issues
+
+| Phase | Name | Issue # | Node ID |
+|-------|------|---------|---------|
+| 1 | Click-to-Navigate with Animated Pan | #48 | 4268617272 |
+| 2 | Cursor Highlight Pulse Effect | #47 | 4268617257 |
+
+### Regression Sub-Issue
+
+| Key | Value |
+|-----|-------|
+| Issue # | — |
+| Node ID | — |

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/progress.md
@@ -10,7 +10,8 @@
 
 | Phase | Name | Started | Completed | Notes |
 |-------|------|---------|-----------|-------|
-| 1 | Click-to-Navigate with Animated Pan | 2026-04-15T11:53:42Z | | |
+| 1 | Click-to-Navigate with Animated Pan | 2026-04-15T11:53:42Z | 2026-04-15T12:00:49Z | Build verified |
+| 2 | Cursor Highlight Pulse Effect | 2026-04-15T12:01:30Z | | |
 | 1 | Click-to-Navigate with Animated Pan | | | Core click handler, animated pan, snackbar feedback |
 | 2 | Cursor Highlight Pulse Effect | | | Animated pulse ring on target cursor |
 

--- a/.agent-context/tasks/click-user-icon-navigate-cursor/spec.md
+++ b/.agent-context/tasks/click-user-icon-navigate-cursor/spec.md
@@ -1,0 +1,55 @@
+# Specification: Click User Icon to Navigate to Their Cursor
+
+## Overview
+
+When multiple users are collaborating on an Event Storming board, it can be difficult to find where a specific person is working, especially on large boards. This feature allows a user to click on another user's avatar icon in the header bar to smoothly pan the board canvas to that user's current cursor position, making it easy to follow along with what a teammate is doing.
+
+## Goals
+
+- Enable quick navigation to any connected user's cursor location by clicking their avatar in the header
+- Provide a smooth, animated pan transition so users don't lose spatial context
+- Give clear visual feedback when the target user's cursor position is unknown
+- Briefly highlight the target user's cursor after navigation so it's easy to spot
+
+## User Stories
+
+- As a collaborator, I want to click on a teammate's icon in the header so that my view pans to where they are working on the board
+- As a collaborator, I want to see the target user's cursor highlighted briefly after navigating so that I can quickly identify their exact position
+- As a collaborator, I want clear feedback when a user has no known cursor position so that I understand why nothing happened
+
+## Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | Clicking a user's avatar circle in the header pans the board canvas so that the target user's last known cursor position is centred on screen | Must |
+| FR-2 | The pan transition is smoothly animated (not an instant snap) | Must |
+| FR-3 | The current zoom level remains unchanged when navigating to a user's cursor | Must |
+| FR-4 | If the target user has no known cursor position (e.g. just joined, hasn't moved their mouse), a tooltip is shown indicating "No cursor position available" | Must |
+| FR-5 | After the pan animation completes, the target user's cursor is visually highlighted with a brief pulse or emphasis animation so it stands out | Should |
+| FR-6 | Clicking the local user's own avatar does nothing (the local user's cursor is always at their own position) | Must |
+| FR-7 | The user avatar circles remain clickable whether the connected users list is collapsed (showing up to 5) or expanded (showing all) | Must |
+
+## Non-Functional Requirements
+
+- The pan animation should feel responsive — complete within 300–500ms
+- The cursor highlight effect should be subtle and non-disruptive, lasting approximately 1–2 seconds
+- No additional network requests should be required — cursor positions are already tracked locally in the `remoteCursors` Map
+
+## Constraints & Assumptions
+
+- Remote cursor positions are already stored on the frontend in `canvasService.remoteCursors` (a Map keyed by `connectionId`)
+- Each `BoardUser` in the header has a `connectionId` that maps to the `remoteCursors` Map key
+- The existing minimap click-to-pan logic (`onMinimapClick`) provides a proven pattern for centring the viewport on a target coordinate
+- Cursor positions become stale after 15 seconds and are pruned — if a user is idle, their cursor may not be available
+- The local user's own cursor position is not stored in `remoteCursors` (only remote cursors are tracked)
+
+## Out of Scope
+
+- Following/tracking a user in real-time (continuous viewport following)
+- Displaying a user's cursor position in the header tooltip
+- Any backend changes — this feature is entirely frontend
+- Adding click-to-navigate for the "+N more users" overflow indicator
+
+## Open Questions
+
+_None — all questions resolved via GitHub issue #46._

--- a/src/eventstormingboard.client/src/app/_shared/services/boards-signalr.service.ts
+++ b/src/eventstormingboard.client/src/app/_shared/services/boards-signalr.service.ts
@@ -74,6 +74,10 @@ export class BoardsSignalRService {
   public agentChatHistory = new Map<string, AgentChatMessage[]>();
   public autonomousStatuses = new Map<string, AutonomousFacilitatorStatus>();
 
+  public get connectionId(): string | null | undefined {
+    return this.hubConnection?.connectionId;
+  }
+
   public getHistoryForBoard(boardId: string): AgentChatMessage[] {
     return this.agentChatHistory.get(boardId) ?? [];
   }

--- a/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, DestroyRef, ElementRef, HostListener, OnInit, inject, viewChild } from '@angular/core';
+import { AfterViewInit, Component, DestroyRef, ElementRef, HostListener, OnDestroy, OnInit, inject, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Note, getNoteColor } from '../../_shared/models/note.model';
 import { Connection } from '../../_shared/models/connection.model';
@@ -27,7 +27,7 @@ import { UserService } from '../../_shared/services/user.service';
     templateUrl: './board-canvas.component.html',
     styleUrls: ['./board-canvas.component.scss']
 })
-export class BoardCanvasComponent implements OnInit, AfterViewInit {
+export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private static readonly CURSOR_BROADCAST_INTERVAL_MS = 50;
 
@@ -43,6 +43,8 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit {
 
   private currentMousePos: Coordinates = { x: 0, y: 0 };
   private rafPending = false;
+  private panAnimationId: number | null = null;
+  private destroyed = false;
 
   private draggingNote: Note | null = null;
   private resizingNote: Note | null = null;
@@ -104,6 +106,54 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit {
     this.canvasService.originY = -canvasY * this.canvasService.scale + canvasEl.height / 2;
 
     this.drawCanvas();
+  }
+
+  private animatePanTo(worldX: number, worldY: number, highlightConnectionId?: string): void {
+    // Cancel any in-flight animation
+    if (this.panAnimationId !== null) {
+      cancelAnimationFrame(this.panAnimationId);
+      this.panAnimationId = null;
+    }
+
+    const canvasEl = this.canvas().nativeElement;
+    const targetOriginX = -worldX * this.canvasService.scale + canvasEl.width / 2;
+    const targetOriginY = -worldY * this.canvasService.scale + canvasEl.height / 2;
+
+    const startOriginX = this.canvasService.originX;
+    const startOriginY = this.canvasService.originY;
+    const duration = 400;
+    const startTime = performance.now();
+
+    const animate = (now: number) => {
+      // Guard against firing after component destroy
+      if (this.destroyed) {
+        this.panAnimationId = null;
+        return;
+      }
+
+      const elapsed = now - startTime;
+      const t = Math.min(elapsed / duration, 1);
+      const eased = t < 1 ? 1 - Math.pow(1 - t, 3) : 1; // easeOutCubic
+
+      this.canvasService.originX = startOriginX + (targetOriginX - startOriginX) * eased;
+      this.canvasService.originY = startOriginY + (targetOriginY - startOriginY) * eased;
+
+      this.drawCanvasFrame();
+
+      if (t < 1) {
+        this.panAnimationId = requestAnimationFrame(animate);
+      } else {
+        this.panAnimationId = null;
+        // Set highlight after animation completes so pulse starts on centered cursor
+        if (highlightConnectionId) {
+          this.canvasService.highlightedCursorConnectionId = highlightConnectionId;
+          this.canvasService.highlightStartTime = Date.now();
+          this.drawCanvas();
+        }
+      }
+    };
+
+    this.panAnimationId = requestAnimationFrame(animate);
   }
 
   public onMouseDown(event: MouseEvent): void {
@@ -577,6 +627,18 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit {
           this.drawCanvas();
         }
       });
+
+    this.canvasService.navigateToCoordinate$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(target => this.animatePanTo(target.x, target.y, target.highlightConnectionId));
+  }
+
+  public ngOnDestroy(): void {
+    this.destroyed = true;
+    if (this.panAnimationId !== null) {
+      cancelAnimationFrame(this.panAnimationId);
+      this.panAnimationId = null;
+    }
   }
 
   public ngAfterViewInit(): void {

--- a/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
@@ -819,6 +819,18 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     this.drawMinimap();
+
+    // Continue redrawing while cursor highlight is active.
+    if (this.canvasService.highlightedCursorConnectionId) {
+      const highlightElapsed = Date.now() - this.canvasService.highlightStartTime;
+      if (highlightElapsed < 1600) {
+        // Slightly over 1500ms duration to ensure final clear frame renders.
+        this.drawCanvas();
+      } else {
+        // Safety expiry if highlighted cursor was pruned before drawRemoteCursors could clear state.
+        this.canvasService.highlightedCursorConnectionId = null;
+      }
+    }
   }
 
   private drawRemoteCursors(): void {
@@ -880,6 +892,38 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
       this.ctx.fillText(cursor.userName, labelX + paddingX, labelY + labelHeight / 2 + 1);
 
       this.ctx.restore();
+
+      if (cursor.connectionId === this.canvasService.highlightedCursorConnectionId) {
+        const elapsed = Date.now() - this.canvasService.highlightStartTime;
+        const highlightDuration = 1500;
+
+        if (elapsed < highlightDuration) {
+          const progress = elapsed / highlightDuration;
+          const radius = 20 + progress * 30;
+          const opacity = (1 - progress) * 0.6;
+
+          this.ctx.save();
+          this.ctx.beginPath();
+          this.ctx.arc(cursor.x, cursor.y, radius, 0, Math.PI * 2);
+          this.ctx.strokeStyle = `rgba(0, 240, 255, ${opacity})`;
+          this.ctx.lineWidth = 2;
+          this.ctx.stroke();
+
+          // Second ring with offset size for a subtle depth effect.
+          const radius2 = 10 + progress * 20;
+          const opacity2 = (1 - progress) * 0.3;
+          this.ctx.beginPath();
+          this.ctx.arc(cursor.x, cursor.y, radius2, 0, Math.PI * 2);
+          this.ctx.strokeStyle = `rgba(0, 240, 255, ${opacity2})`;
+          this.ctx.lineWidth = 1.5;
+          this.ctx.stroke();
+
+          this.ctx.restore();
+        } else {
+          // Clear highlight after duration.
+          this.canvasService.highlightedCursorConnectionId = null;
+        }
+      }
     }
   }
 

--- a/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.component.ts
@@ -92,6 +92,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
   public minimap = viewChild.required<ElementRef<HTMLCanvasElement>>('minimap');
 
   public onMinimapClick(event: MouseEvent): void {
+    this.cancelPanAnimation();
     const rect = this.minimap().nativeElement.getBoundingClientRect();
     const clickX = event.clientX - rect.left;
     const clickY = event.clientY - rect.top;
@@ -108,12 +109,17 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
     this.drawCanvas();
   }
 
-  private animatePanTo(worldX: number, worldY: number, highlightConnectionId?: string): void {
-    // Cancel any in-flight animation
+  private cancelPanAnimation(): void {
     if (this.panAnimationId !== null) {
       cancelAnimationFrame(this.panAnimationId);
       this.panAnimationId = null;
     }
+  }
+
+  private animatePanTo(worldX: number, worldY: number, highlightConnectionId?: string): void {
+    this.cancelPanAnimation();
+    // Clear any stale highlight from a previous navigation
+    this.canvasService.highlightedCursorConnectionId = null;
 
     const canvasEl = this.canvas().nativeElement;
     const targetOriginX = -worldX * this.canvasService.scale + canvasEl.width / 2;
@@ -157,6 +163,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public onMouseDown(event: MouseEvent): void {
+    this.cancelPanAnimation();
     const { x, y } = this.getMousePos(event);
 
     if ((this.canvasService.isPanningMode && event.button === 0) || event.button === 1) { // Left mouse button for panning
@@ -443,6 +450,7 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public onWheel(event: WheelEvent): void {
+    this.cancelPanAnimation();
     if (event.ctrlKey) {
       // Ctrl pressed: Zooming behavior  
       event.preventDefault();
@@ -635,10 +643,8 @@ export class BoardCanvasComponent implements OnInit, AfterViewInit, OnDestroy {
 
   public ngOnDestroy(): void {
     this.destroyed = true;
-    if (this.panAnimationId !== null) {
-      cancelAnimationFrame(this.panAnimationId);
-      this.panAnimationId = null;
-    }
+    this.cancelPanAnimation();
+    this.canvasService.highlightedCursorConnectionId = null;
   }
 
   public ngAfterViewInit(): void {

--- a/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts
+++ b/src/eventstormingboard.client/src/app/board/board-canvas/board-canvas.service.ts
@@ -32,6 +32,9 @@ export class BoardCanvasService {
 
   public canvasUpdated$ = new Subject<void>();
   public canvasImageDownloaded$ = new Subject<void>();
+  public navigateToCoordinate$ = new Subject<{ x: number; y: number; highlightConnectionId?: string }>();
+  public highlightedCursorConnectionId: string | null = null;
+  public highlightStartTime = 0;
 
   public originX = 0;
   public originY = 0;

--- a/src/eventstormingboard.client/src/app/board/board.component.html
+++ b/src/eventstormingboard.client/src/app/board/board.component.html
@@ -25,8 +25,10 @@
     @for (user of (isConnectedUsersHovered ? connectedUsers : connectedUsers.slice(0, 5)); track user) {
       <div
         class="user-circle"
+        [class.local-user]="user.connectionId === localConnectionId"
         [style.background-color]="user.getColour()"
-        [matTooltip]="user.userName">
+        [matTooltip]="user.userName"
+        (click)="navigateToUserCursor(user)">
         {{ user.userName.charAt(0).toUpperCase() }}
       </div>
     }

--- a/src/eventstormingboard.client/src/app/board/board.component.scss
+++ b/src/eventstormingboard.client/src/app/board/board.component.scss
@@ -67,8 +67,12 @@
     text-transform: uppercase;
     box-shadow: 0 0 0 2px var(--sys-surface-container-low);
     margin-left: -10px;
-    cursor: default;
+    cursor: pointer;
     transition: transform var(--duration-normal) var(--ease-sharp);
+
+    &.local-user {
+      cursor: default;
+    }
 
     &:first-child {
       margin-left: 0;

--- a/src/eventstormingboard.client/src/app/board/board.component.ts
+++ b/src/eventstormingboard.client/src/app/board/board.component.ts
@@ -7,6 +7,7 @@ import { AutonomousFacilitatorStatus, BoardsSignalRService } from '../_shared/se
 import { MatButtonModule } from '@angular/material/button';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
@@ -43,6 +44,7 @@ interface ImportedBoardState {
     imports: [
         MatButtonModule,
         MatIconModule,
+        MatSnackBarModule,
         MatTooltipModule,
         CommonModule,
         FormsModule,
@@ -61,6 +63,7 @@ export class BoardComponent implements OnInit, OnDestroy {
   private activatedRoute = inject(ActivatedRoute);
   private boardsService = inject(BoardsService);
   private dialog = inject(MatDialog);
+  private snackBar = inject(MatSnackBar);
   private userService = inject(UserService);
   private destroyRef = inject(DestroyRef);
   private id!: string;
@@ -97,8 +100,35 @@ export class BoardComponent implements OnInit, OnDestroy {
     });
   }
 
+  get localConnectionId(): string | null | undefined {
+    return this.boardsHub.connectionId;
+  }
+
   public isPhaseActive(phase: string): boolean {
     return this.canvasService.boardState.phase === phase;
+  }
+
+  public navigateToUserCursor(user: BoardUser): void {
+    const localId = this.boardsHub.connectionId;
+    if (!localId || user.connectionId === localId) {
+      return;
+    }
+
+    const cursor = this.canvasService.remoteCursors.get(user.connectionId);
+    if (!cursor) {
+      this.snackBar.open('No cursor position available', '', {
+        duration: 2000,
+        horizontalPosition: 'center',
+        verticalPosition: 'top'
+      });
+      return;
+    }
+
+    this.canvasService.navigateToCoordinate$.next({
+      x: cursor.x,
+      y: cursor.y,
+      highlightConnectionId: cursor.connectionId
+    });
   }
 
   public exportBoardAsJSON(): void {


### PR DESCRIPTION
Closes #46

Adds the ability to click a user's icon in the board to navigate the canvas viewport to that user's current cursor position.